### PR TITLE
Add WLED and Touchscreen for Xiaomi Redmi Note 7

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender.dts
@@ -89,6 +89,18 @@
 	};
 };
 
+&blsp_i2c1 {
+	status = "okay";
+
+	touchscreen: novatek@62 {
+		compatible = "novatek,nt36525";
+		reg = <0x62>;
+		interrupt-parent = <&tlmm>;
+		interrupts = <67 IRQ_TYPE_EDGE_RISING>;
+		reset-gpios = <&tlmm 66 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &blsp1_uart2 {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender.dts
@@ -363,6 +363,14 @@
 	};
 };
 
+&pm660l_wled {
+	status = "okay";
+
+	qcom,switching-freq = <800>;
+	qcom,current-limit-microamp = <20000>;
+	qcom,num-strings = <2>;
+};
+
 &sdhc_1 {
 	status = "okay";
 	supports-cqe;


### PR DESCRIPTION
The WLED patch is currently on Patchwork (https://patchwork.kernel.org/project/linux-arm-msm/patch/20220425032824.211975-1-danct12@riseup.net/)

And the touchscreen patch should not be upstreamed until the touchscreen driver is in the kernel.