### PR TITLE
fixup! arm64: dts: qcom: add device-tree for Redmi Note 6 Pro (tulip)

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -24,6 +24,7 @@
 
 	aliases {
 		serial0 = &blsp1_uart2;
+		serial1 = &blsp2_uart1;
 	};
 
 	battery: battery {
@@ -203,8 +204,6 @@
 };
 
 &pm660l_wled {
-	default-brightness = <512>;
-
 	status = "okay";
 };
 


### PR DESCRIPTION
Add serial1 alias for blsp2_uart1. This makes bluetooth detected and usable.
```
[   29.803931] Bluetooth: hci0: setting up wcn399x
[   29.941403] Bluetooth: hci0: QCA Product ID   :0x0000000a
[   29.941433] Bluetooth: hci0: QCA SOC Version  :0x40020140
[   29.941439] Bluetooth: hci0: QCA ROM Version  :0x00000201
[   29.941444] Bluetooth: hci0: QCA Patch Version:0x00000001
[   29.958938] Bluetooth: hci0: QCA controller version 0x01400201
[   29.958963] Bluetooth: hci0: QCA Downloading qca/crbtfw21.tlv
```