### PR TITLE
arm64: dts: qcom: pm660: add spmi-haptics node

### DIFF
--- a/arch/arm64/boot/dts/qcom/pm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/pm660.dtsi
@@ -5,6 +5,7 @@
 
 #include <dt-bindings/iio/qcom,spmi-vadc.h>
 #include <dt-bindings/input/linux-event-codes.h>
+#include <dt-bindings/input/qcom,spmi-haptics.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/spmi/spmi.h>
 #include <dt-bindings/thermal/thermal.h>
@@ -232,6 +233,23 @@
 		reg = <0x1 SPMI_USID>;
 		#address-cells = <1>;
 		#size-cells = <0>;
+
+		pm660_haptics: haptics@c000 {
+			compatible = "qcom,pmi8998-haptics", "qcom,spmi-haptics";
+			reg = <0xc000>;
+
+			interrupts = <0x1 0xc0 0x0 IRQ_TYPE_EDGE_BOTH>,
+					<0x1 0xc0 0x1 IRQ_TYPE_EDGE_BOTH>;
+			interrupt-names = "short", "play";
+
+			qcom,actuator-type = <HAP_TYPE_LRA>;
+			qcom,brake-pattern = <0x3 0x3 0x0 0x0>;
+			qcom,play-mode = <HAP_PLAY_BUFFER>;
+			qcom,wave-play-rate-us = <6667>;
+			qcom,wave-shape = <HAP_WAVE_SQUARE>;
+
+			status = "disabled";
+		};
 
 		pm660_spmi_regulators: regulators {
 			compatible = "qcom,pm660-regulators";


### PR DESCRIPTION
dmesg shows
```
input: spmi_haptics as /devices/platform/soc@0/800f000.spmi/spmi-0/0-01/800f000.spmi:pmic@1:haptics@c000/input/input3
```


