### PR TITLE
fixup! arm64: dts: qcom: add device-tree for Redmi Note 6 Pro (tulip)

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -10,10 +10,6 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/input/gpio-keys.h>
 
-/delete-node/ &adsp_mem;
-/delete-node/ &qhee_code;
-/delete-node/ &qseecom_mem;
-/delete-node/ &rmtfs_mem;
 /delete-node/ &tz_mem;
 /delete-node/ &zap_shader_region;
 
@@ -51,6 +47,23 @@
 		};
 	};
 
+	gpio-hall-sensor {
+		compatible = "gpio-keys";
+		label = "Hall effect sensor";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&hall_sensor_default>;
+
+		hall-sensor {
+			label = "Hall Effect Sensor";
+			gpios = <&tlmm 75 GPIO_ACTIVE_LOW>;
+			linux,input-type = <EV_SW>;
+			linux,code = <SW_LID>;
+			linux,can-disable;
+			wakeup-source;
+		};
+	};
+
 	gpio-keys {
 		compatible = "gpio-keys";
 
@@ -72,6 +85,11 @@
 			no-map;
 		};
 
+		dfps_data_mem@9f7ff000 {
+			reg = <0x0 0x9f7ff000 0x0 0x1000>;
+			no-map;
+		};
+
 		ramoops@a0000000 {
 			compatible = "ramoops";
 			reg = <0x0 0xa0000000 0x0 0x400000>;
@@ -79,11 +97,6 @@
 			record-size = <0x20000>;
 			ftrace-size = <0x0>;
 			pmsg-size = <0x20000>;
-		};
-
-		qseecom_mem: qseecom-region@f5800000 {
-			reg = <0x0 0xf5800000 0x0 0x1400000>;
-			no-map;
 		};
 	};
 
@@ -196,6 +209,10 @@
 	qcom,min-voltage-uv= <3400000>;
 	qcom,max-voltage-uv= <4408000>;
 
+	status = "okay";
+};
+
+&pm660_haptics {
 	status = "okay";
 };
 
@@ -472,6 +489,14 @@
 
 &tlmm {
 	gpio-reserved-ranges = <8 4>;
+
+	hall_sensor_default: hall-sensor-state {
+		pins = "gpio75";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+		input-enable;
+	};
 
 	ts_rst_n: ts-rst-n-state {
 		pins = "gpio66";


### PR DESCRIPTION
After some analysis, removed regions are the same as declared within in sdm660.dtsi.
This sports:
- wifi enablement
- spmi-haptics node
- remoteprocfs fixes (now rmtfs daemon sees /dev/qcom_rmtfs_mem1e)
- add hall sensor

Known issues:
```
[   65.457083] qcom-q6v5-mss 4080000.remoteproc: fatal error received: err_qdi.c:459:EX:wlan_process:1:WLAN RT:1087:PC=b00c87e0
[   65.465433] remoteproc remoteproc1: crash detected in 4080000.remoteproc: type fatal error
[   65.473827] remoteproc remoteproc1: handling crash #3 in 4080000.remoteproc
[   65.482046] remoteproc remoteproc1: recovering 4080000.remoteproc
[   65.524203] ath10k_snoc 18800000.wifi: firmware crashed! (guid ad8cb34b-385c-4465-8e32-c02cb94593f6)
[   65.532747] ath10k_snoc 18800000.wifi: wcn3990 hw1.0 target 0x00000008 chip_id 0x00000000 sub 0000:0000
[   65.540995] ath10k_snoc 18800000.wifi: kconfig debug 1 debugfs 1 tracing 0 dfs 0 testmode 0
[   65.549050] ath10k_snoc 18800000.wifi: firmware ver 1.0.0.591 api 5 features wowlan,mgmt-tx-by-reference,non-bmi crc32 b3d4b790
[   65.557163] ath10k_snoc 18800000.wifi: board_file api 2 bmi_id N/A crc32 00000000
[   65.565221] ath10k_snoc 18800000.wifi: htt-ver 3.58 wmi-op 4 htt-op 3 cal file max-sta 32 raw 0 hwcrypto 1
[   65.594267] qcom-q6v5-mss 4080000.remoteproc: port failed halt
[   65.608939] remoteproc remoteproc1: stopped remote processor 4080000.remoteproc
[   65.730295] qcom-q6v5-mss 4080000.remoteproc: MBA booted without debug policy, loading mpss
[   67.384927] remoteproc remoteproc1: remote processor 4080000.remoteproc is now up
[   68.574331] ath10k_snoc 18800000.wifi: failed to set PS Mode 1 for vdev 0: -108
[   68.594242] ath10k_snoc 18800000.wifi: failed to setup powersave: -108
[   68.610239] ath10k_snoc 18800000.wifi: failed to setup ps on vdev 0: -108
[   68.626277] ath10k_snoc 18800000.wifi: failed to set vdev wmm params on vdev 1: -108
[   68.642312] ath10k_snoc 18800000.wifi: failed to set vdev wmm params on vdev 1: -108
[   68.658252] ath10k_snoc 18800000.wifi: failed to set vdev wmm params on vdev 1: -108
[   68.674252] ath10k_snoc 18800000.wifi: failed to set vdev wmm params on vdev 1: -108
[   68.690251] ath10k_snoc 18800000.wifi: device successfully recovered
[   70.015739] ath10k_snoc 18800000.wifi: failed to start hw scan: -108
[   70.436591] ieee80211 phy0: Hardware restart was requested
```

I've already done lots of attempts with qca-swissarmyknife and official ath10k board-2.bin and firmware-5.bin but firmware crashes after a while.

Wifi APs are detected and associated.
