### PR TITLE
6.9 USB fixes for other devices

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-nokia-pl2.dts
+++ b/arch/arm64/boot/dts/qcom/sdm630-nokia-pl2.dts
@@ -252,17 +252,17 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&panel_reset_gpio &panel_te_gpio>;
 
-                port {
-                        panel_in: endpoint {
-                                remote-endpoint = <&mdss_dsi0_out>;
-                        };
-                };
-        };
+		port {
+			panel_in: endpoint {
+				remote-endpoint = <&mdss_dsi0_out>;
+			};
+		};
+	};
 };
 
 &mdss_dsi0_out {
-        data-lanes = <0 1 2 3>;
-        remote-endpoint = <&panel_in>;
+	data-lanes = <0 1 2 3>;
+	remote-endpoint = <&panel_in>;
 };
 
 &mdss_dsi0_phy {
@@ -324,8 +324,8 @@
 };
 
 &pm660l_wled {
-        status = "okay";
-        default-brightness = <512>;
+	status = "okay";
+	default-brightness = <512>;
 };
 
 &pm660_charger {
@@ -343,6 +343,14 @@
 
 &pm660_rradc {
 	status = "okay";
+};
+
+&qusb2phy0 {
+	status = "okay";
+
+	vdd-supply = <&vreg_l1b_0p925>;
+	vdda-pll-supply = <&vreg_l10a_1p8>;
+	vdda-phy-dpdm-supply = <&vreg_l7b_3p125>;
 };
 
 &rpm_requests {
@@ -679,10 +687,16 @@
 };
 
 &usb3 {
+	qcom,select-utmi-as-pipe-clk;
+
 	status = "okay";
 };
 
 &usb3_dwc3 {
+	maximum-speed = "high-speed";
+	phys = <&qusb2phy0>;
+	phy-names = "usb2-phy";
+
 	dr_mode = "peripheral";
 	extcon = <&extcon_usb>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
@@ -603,8 +603,8 @@
 };
 
 &pm660l_wled {
-        status = "okay";
-        default-brightness = <512>;
+	status = "okay";
+	default-brightness = <512>;
 };
 
 &gcc {
@@ -620,19 +620,19 @@
 };
 
 &mmss_smmu {
-        status = "okay";
+	status = "okay";
 };
 
 &anoc2_smmu {
-        status = "okay";
+	status = "okay";
 };
 
 &kgsl_smmu {
-        status = "okay";
+	status = "okay";
 };
 
 &lpass_smmu {
-        status = "okay";
+	status = "okay";
 };
 
 &adreno_gpu {

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -575,10 +575,15 @@
 };
 
 &usb3 {
+	qcom,select-utmi-as-pipe-clk;
+
 	status = "okay";
 };
 
 &usb3_dwc3 {
+	maximum-speed = "high-speed";
+	phys = <&qusb2phy0>;
+	phy-names = "usb2-phy";
 	dr_mode = "peripheral";
 
 	status = "okay";

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
@@ -247,11 +247,16 @@
 };
 
 &usb3 {
+	qcom,select-utmi-as-pipe-clk;
+
 	status = "okay";
 };
 
 &usb3_dwc3 {
-	status = "okay";
+	maximum-speed = "high-speed";
+	phys = <&qusb2phy0>;
+	phy-names = "usb2-phy";
+
 	dr_mode = "peripheral";
 	extcon = <&extcon_usb>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-platina.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-platina.dts
@@ -773,10 +773,16 @@
 };
 
 &usb3 {
+	qcom,select-utmi-as-pipe-clk;
+
 	status = "okay";
 };
 
 &usb3_dwc3 {
+	maximum-speed = "high-speed";
+	phys = <&qusb2phy0>;
+	phy-names = "usb2-phy";
+
 	dr_mode = "peripheral";
 	extcon = <&extcon_usb>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-platina.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-platina.dts
@@ -192,8 +192,7 @@
 
 	gpio_keys {
 		status = "okay";
-		compatible = "gpio-keys-polled";
-		poll-interval = <100>;
+		compatible = "gpio-keys";
 		label = "Volume up";
 		pinctrl-names = "default";
 		pinctrl-0 = <&vol_up_gpio_default>;
@@ -752,15 +751,15 @@
 
 };
 
-&adreno_gpu{
+&adreno_gpu {
 	status = "disabled";
 };
 
-&gpucc{
+&gpucc {
 	status = "disabled";
 };
 
-&mmcc{
+&mmcc {
 	status = "disabled";
 };
 


### PR DESCRIPTION
Upstream commit https://lore.kernel.org/all/20240116-sdm660-usb3-support-v1-3-2fbd683aea77@linaro.org/ changed how devices should describe their USB. Basically:
* `qcom,select-utmi-as-pipe-clk` was removed from sdm630.dtsi `usb3` node, each device now has to specify it individually
* `maximum-speed = "high-speed"`, `phys = <&qusb2phy0>`, `phy-names = "usb2-phy"` were removed from sdm630.dtsi `usb3_dwc3` node, each device now has to specify them individually.
See the changes in above mentioned lore patchset for `sdm660-xiaomi-lavender.dts` for general idea.

Other style fixes:
* missing spaces
* convert spaces to tabs