### PR TITLE
Fix drm device probe ordering with strict fw_devlink

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
@@ -45,7 +45,12 @@
 
 			/* In order to allow simpledrm framebuffer to know
 			 * physical dimensions */
-			panel = <&panel>;
+			panel = <&fb_panel>;
+
+			fb_panel: fb-panel {
+				width-mm = <68>;
+				height-mm = <136>;
+			}
 		};
 	};
 
@@ -578,9 +583,6 @@
 
 		reset-gpios = <&tlmm 53 GPIO_ACTIVE_HIGH>;
 		disp-te-gpios = <&tlmm 59 GPIO_ACTIVE_HIGH>;
-
-		width-mm = <68>;
-		height-mm = <136>;
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&panel_reset_gpio &panel_te_gpio>;

--- a/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
@@ -50,7 +50,7 @@
 			fb_panel: fb-panel {
 				width-mm = <68>;
 				height-mm = <136>;
-			}
+			};
 		};
 	};
 

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -47,7 +47,12 @@
 
 			/* In order to allow simple-framebuffer to know
 			 * physical dimensions */
-			panel = <&panel>;
+			panel = <&fb_panel>;
+
+			fb_panel: fb-panel {
+				width-mm = <68>;
+				height-mm = <143>;
+			};
 		};
 	};
 
@@ -183,9 +188,6 @@
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&mdss_dsi_active &mdss_te_active>;
-
-		width-mm = <68>;
-		height-mm = <143>;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -148,11 +148,11 @@
 };
 
 &mdss {
-	// status = "okay"; // TODO: enable this when panel works
+	status = "disabled"; // TODO: enable this when panel works
 };
 
 &mmcc {
-	// status = "okay"; // TODO: enable this when panel works
+	status = "disabled"; // TODO: enable this when panel works
 };
 
 &mmss_smmu {

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-plus.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-plus.dts
@@ -118,17 +118,10 @@
 
 		backlight = <&i2c_backlight>;
 
-		reset-gpios = <&tlmm 62 GPIO_ACTIVE_HIGH>; // not used by panel-simple
-		//disp-te-gpios = <&pm660l_gpios GPIO_ACTIVE_HIGH>; // used by msm dsi host
+		reset-gpios = <&tlmm 62 GPIO_ACTIVE_HIGH>;
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&mdss_dsi_active &mdss_te_active>;
-
-		//pp1800-supply = <&vreg_l11a_1p8>; // wqhd-vddio-supply
-		// supply is the same for touchscreen
-
-		width-mm = <135>;
-		height-mm = <216>;
 
 		port {
 			panel_in: endpoint {
@@ -149,9 +142,14 @@
 };
 
 &simplefb {
-	/* In order to allow simledrm framebuffer to know panel
-	 * physical size to allow userspace to do proper DPI scaling */
-	panel = <&panel>;
+	/* Let simledrm framebuffer to know panel physical size to
+	   allow userspace to do proper DPI scaling */
+	panel = <&fb_panel>;
+
+	fb_panel: fb-panel {
+		width-mm = <135>;
+		height-mm = <216>;
+	};
 };
 
 &tlmm {

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
@@ -38,6 +38,23 @@
 			height = <2340>;
 			stride = <(1080 * 4)>;
 			format = "a8r8g8b8";
+
+			/* HACK:
+			 * Fake panel node for simple-framebuffer to calculate DPI from. Only
+			 * needs width & height specified. This allows us to break device link
+			 * from simplefb to mdss (implicitly via panel->mdp->mdss) to fix drm
+			 * device probe ordering. Without this, simpledrm would probe second
+			 * after msm-drm, and confuse userspace with 2 GPUs in /dev/dri.
+			 * Alternative workaround is to boot with kernel parameter
+			 * `fw_devlink=permissive`, which is worse, because it can hide other
+			 * issues with device dependencies.
+			 */
+			panel = <&fb_panel>;
+
+			fb_panel: fb-panel {
+				width-mm = <67>;
+				height-mm = <145>;
+			};
 		};
 	};
 


### PR DESCRIPTION
Add fake panel node for simple-fbramebuffer to calculate DPI from. It only needs width & height specified. This allows us to break device link from simplefb to mdss (implicitly via panel->mdp->mdss) to fix drm device probe ordering.

Without this, mdss/adreno probes first, creates `/dev/dri/card0`, simpledrm would probe second after msm-drm, create `/dev/dri/card1`, resulting in two cards and confuse userspace with 2 GPUs (UIs fail to start). When there is no dependency on mdss for simpledrm, it probes first, creates card0. After that, mdss/adreno probes, takes over the framebuffer, removes card0 and adds it's own card1 :thinking:  At least what I think is happening.

Alternative workaround is to boot with kernel parameter  `fw_devlink=permissive`, which also can break this dependency, but is worse, because it can hide other issues with device dependencies.