### PR TITLE
arm64: dts: qcom: sdm636-xiaomi-tulip: enable spi_7 interface

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -1018,6 +1018,20 @@
 					drive-strength = <2>;
 				};
 			};
+
+			spi7_default: spi7-default-state {
+				pins = "gpio24", "gpio25", "gpio26", "gpio27";
+				function = "blsp_spi7";
+				drive-strength = <6>;
+				bias-disable;
+			};
+
+			spi7_sleep: spi7-sleep-state {
+				pins = "gpio24", "gpio25", "gpio26", "gpio27";
+				function = "blsp_spi7";
+				drive-strength = <6>;
+				bias-disable;
+			};
 		};
 
 		remoteproc_mss: remoteproc@4080000 {
@@ -1961,6 +1975,26 @@
 			pinctrl-names = "default", "sleep";
 			pinctrl-0 = <&i2c7_default>;
 			pinctrl-1 = <&i2c7_sleep>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		blsp_spi7: spi@c1b7000 {
+			compatible = "qcom,spi-qup-v2.2.1";
+			reg = <0x0c1b7000 0x600>;
+			interrupts = <GIC_SPI 103 IRQ_TYPE_LEVEL_HIGH>;
+
+			clocks = <&gcc GCC_BLSP2_QUP3_I2C_APPS_CLK>,
+				 <&gcc GCC_BLSP2_AHB_CLK>;
+			clock-names = "core", "iface";
+			clock-frequency = <400000>;
+			dmas = <&blsp2_dma 8>, <&blsp2_dma 9>;
+			dma-names = "tx", "rx";
+
+			pinctrl-names = "default", "sleep";
+			pinctrl-0 = <&spi7_default>;
+			pinctrl-1 = <&spi7_sleep>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -153,6 +153,10 @@
 	status = "okay";
 };
 
+&blsp_spi7 {
+	status = "okay";
+};
+
 &blsp1_uart2 {
 	status = "okay";
 };


### PR DESCRIPTION
This enables spi_7 interface on xiaomi-tulip

dmesg:

`[    2.797349] spi_qup c1b7000.spi: IN:block:16, fifo:64, OUT:block:16, fifo:64`

downstream references:
https://github.com/Genom-Project/android_kernel_xiaomi_tulip/blob/2e83ae9ce4cdfafe5908c802ae1d159ca5e26753/arch/arm/boot/dts/qcom/sdm660-blsp.dtsi#L397

https://github.com/Genom-Project/android_kernel_xiaomi_tulip/blob/2e83ae9ce4cdfafe5908c802ae1d159ca5e26753/arch/arm/boot/dts/qcom/sdm660-pinctrl.dtsi#L839

There is also an enabled device, I tried with:
```
&blsp_spi7 {
	status = "okay";

        spidev@1 {
		compatible = "rohm,dh2228fv";
                reg = <1>;
                spi-cpol;
                spi-max-frequency = <1000000>;
        };
};
```
But I have write failures, I think should be (similarly to msm8953 devices), the IR blaster