### PR TITLE
arm64: dts: qcom: sdm636-xiaomi-tulip: enable Adreno 509 gpu

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -104,6 +104,31 @@
 	};
 };
 
+&adreno_gpu {
+	status = "okay";
+
+	opp-table {
+		/delete-node/ opp-700000000;
+
+		opp-430000000 {
+			opp-hz = /bits/ 64 <430000000>;
+			opp-level = <RPM_SMD_LEVEL_SVS_PLUS>;
+			opp-supported-hw = <0xff>;
+		};
+
+		opp-370000000 {
+			opp-hz = /bits/ 64 <370000000>;
+			opp-level = <RPM_SMD_LEVEL_SVS>;
+			opp-peak-kBps = <2188000>;
+			opp-supported-hw = <0xff>;
+		};
+	};
+
+	zap-shader {
+		firmware-name = "qcom/a512_zap.mdt";
+	};
+};
+
 &adsp_pil {
 	status = "okay";
 };
@@ -161,13 +186,30 @@
 	};
 };
 
+&gpucc {
+	status = "okay";
+};
+
+&kgsl_smmu {
+	status = "okay";
+};
+
 &lpass_smmu {
 	status = "okay";
 };
 
+&mdss {
+	status = "okay";
+};
+
 &mdss_dsi0 {
+	status = "okay";
+
 	#address-cells = <1>;
 	#size-cells = <0>;
+
+	vdd-supply = <&vreg_l1b_0p925>;
+	vdda-supply = <&vreg_l1a_1p225>;
 
 	panel: panel@0 {
 		compatible = "tianma,nt36672a-xiaomi-tulip-simple";
@@ -179,7 +221,27 @@
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&mdss_dsi_active &mdss_te_active>;
+
+		port {
+			panel_in: endpoint {
+				remote-endpoint = <&mdss_dsi0_out>;
+			};
+		};
 	};
+};
+
+&mdss_dsi0_out {
+	data-lanes = <0 1 2 3>;
+	remote-endpoint = <&panel_in>;
+};
+
+&mdss_dsi0_phy {
+	vcca-supply = <&vreg_l1b_0p925>;
+	status = "okay";
+};
+
+&mmss_smmu {
+	status = "okay";
 };
 
 &pm660_charger {

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -10,8 +10,6 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/input/gpio-keys.h>
 
-/delete-node/ &tz_mem;
-
 / {
 	model = "Xiaomi Redmi Note 6 Pro";
 	compatible = "xiaomi,tulip", "qcom,sdm660", "qcom,sdm636";
@@ -44,15 +42,6 @@
 			height = <2280>;
 			stride = <(1080 * 4)>;
 			format = "a8r8g8b8";
-
-			/* In order to allow simple-framebuffer to know
-			 * physical dimensions */
-			panel = <&fb_panel>;
-
-			fb_panel: fb-panel {
-				width-mm = <68>;
-				height-mm = <143>;
-			};
 		};
 	};
 
@@ -116,8 +105,6 @@
 };
 
 &adsp_pil {
-	firmware-name = "adsp.mdt";
-
 	status = "okay";
 };
 
@@ -481,6 +468,13 @@
 			regulator-enable-ramp-delay = <250>;
 		};
 
+		vreg_l16a_2p7: l16 {
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <2800000>;
+			regulator-enable-ramp-delay = <250>;
+			regulator-always-on;
+		};
+
 		vreg_l17a_1p8: l17 {
 			regulator-min-microvolt = <1650000>;
 			regulator-max-microvolt = <2950000>;
@@ -553,7 +547,7 @@
 
 	mdss_te_active: mdss_te_active {
 		pins = "gpio59";
-		function = "gpio";
+		function = "mdp_vsync";
 		drive-strength = <2>;
 		bias-pull-down;
 	};
@@ -591,8 +585,6 @@
 	phys = <&qusb2phy0>;
 	phy-names = "usb2-phy";
 	dr_mode = "peripheral";
-
-	status = "okay";
 };
 
 &venus {


### PR DESCRIPTION
This also include some cleanup and additional fixes.

The issues was due to unused `a512_zap.mbn` although I place it in the proper place with:
`install -Dm644 qcom/a512_zap.elf "$pkgdir/$_fwdir/postmarketos/a512_zap.mbn"`

If I set it with `firmware-name = "qcom/a512_zap.mdt"` (already provided), everything works with common error `failed to find OPP for freq 500000000 (-34)`
