### PR TITLE
HACK: comment out vmmc-supply from sdhc_2 to allow to boot from SD card on clover

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -574,7 +574,7 @@
 &sdhc_2 {
 	status = "okay";
 
-	vmmc-supply = <&vreg_l5b_2p95>;
+//	vmmc-supply = <&vreg_l5b_2p95>;
 	vqmmc-supply = <&vreg_l2b_2p95>;
 };
 


### PR DESCRIPTION
With vmmc-supply set as vreg_l5b_2p95 system cannot boot from sdcard with following error:

`mmc2: error -110 whilst initialising SD card`

With vmmc-supply unset system can boot from sdcard, so comment out a vmmc-supply to allow system to boot from sdcard