### PR TITLE
Various lavender & clover DT fixes, mostly for SD/eMMC

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -164,9 +164,7 @@
 
 &pm660_fg {
 	monitored-battery = <&battery>;
-	qcom,battery-capacity-ua = <4000000>;
-	qcom,min-voltage-uv= <3400000>;
-	qcom,max-voltage-uv= <4408000>;
+	power-supplies = <&pm660_charger>;
 
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -274,7 +274,7 @@
 		/* SDHCI 3.3V signal doesn't seem to be supported. */
 		vreg_l2b_2p95: l2 {
 			regulator-min-microvolt = <1648000>;
-			regulator-max-microvolt = <2696000>;
+			regulator-max-microvolt = <3100000>;
 			regulator-enable-ramp-delay = <250>;
 			regulator-allow-set-load;
 		};
@@ -316,7 +316,6 @@
 			regulator-enable-ramp-delay = <250>;
 			regulator-ramp-delay = <0>;
 			regulator-allow-set-load;
-			regulator-system-load = <800000>;
 		};
 
 		vreg_l6b_3p3: l6 {
@@ -560,16 +559,21 @@
 };
 
 &sdhc_1 {
-	bus-width = <8>;
-	non-removable;
-	mmc-ddr-1_8v;
+	supports-cqe;
+
 	mmc-hs200-1_8v;
 	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
+
+	vmmc-supply = <&vreg_l4b_2p95>;
+	vqmmc-supply = <&vreg_l8a_1p8>;
 
 	status = "okay";
 };
 
 &sdhc_2 {
+	cd-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
+
 	vmmc-supply = <&vreg_l5b_2p95>;
 	vqmmc-supply = <&vreg_l2b_2p95>;
 

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
@@ -296,7 +296,7 @@
 		/* SDHCI 3.3V signal doesn't seem to be supported. */
 		vreg_l2b_2p95: l2 {
 			regulator-min-microvolt = <1648000>;
-			regulator-max-microvolt = <2696000>;
+			regulator-max-microvolt = <3100000>;
 			regulator-enable-ramp-delay = <250>;
 			regulator-allow-set-load;
 		};
@@ -332,7 +332,6 @@
 			regulator-max-microvolt = <3328000>;
 			regulator-enable-ramp-delay = <250>;
 			regulator-allow-set-load;
-			regulator-system-load = <800000>;
 		};
 
 		vreg_l7b_3p125: l7 {

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
@@ -538,6 +538,8 @@
 &sdhc_2 {
 	status = "okay";
 
+	cd-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
+
 	vmmc-supply = <&vreg_l5b_2p95>;
 	vqmmc-supply = <&vreg_l2b_2p95>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
@@ -207,9 +207,7 @@
 
 &pm660_fg {
 	monitored-battery = <&battery>;
-	qcom,battery-capacity-ua = <4000000>;
-	qcom,min-voltage-uv= <3400000>;
-	qcom,max-voltage-uv= <4408000>;
+	power-supplies = <&pm660_charger>;
 
 	status = "okay";
 };


### PR DESCRIPTION
* Add missing SD card detect gpios
* **clover**: bus-width and non-removable are already set in base dtsi;
* **clover**: add supplies to eMMC (l4b & l8a)
* **clover**: specify CQE and HS400 enhanced strobe in supported modes
* raise SD vqmmc (`l2b`) voltage to 3.1V to trick the driver into believing in `CORE_3_0V_SUPPORT`
* remove `regulator-system-load` from SD vmmc (`l5b`) supply, now sdhci-msm driver sets the load of 800mA itself after d777a15373a209e8bd81ebbbeddd1f4d489054f2
* Add missing power-supplies to fuelgauge