### PR TITLE
arm64: dts: qcom: sdm660-clover-common: describe LED as white

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -186,17 +186,13 @@
 
 	status = "okay";
 
-	multi-led {
-		color = <LED_COLOR_ID_RGB>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	led@3 {
+		reg = <3>;
+		color = <LED_COLOR_ID_WHITE>;
 		function = LED_FUNCTION_STATUS;
-
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		led@3 {
-			reg = <3>;
-			color = <LED_COLOR_ID_RED>;
-		};
 	};
 };
 


### PR DESCRIPTION
Led indicator isn't an RGB one. Describe it as white. Thanks to @FieryFlames for idea.