### PR TITLE
arm64: dts: qcom: sdm636-xiaomi-tulip: describe LED as white

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -9,6 +9,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/input/gpio-keys.h>
+#include <dt-bindings/leds/common.h>
 
 / {
 	model = "Xiaomi Redmi Note 6 Pro";
@@ -244,6 +245,20 @@
 
 &pm660_rradc {
 	status = "okay";
+};
+
+&pm660l_lpg {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	qcom,power-source = <1>;
+
+	status = "okay";
+
+	led@3 {
+		reg = <3>;
+		color = <LED_COLOR_ID_WHITE>;
+		function = LED_FUNCTION_STATUS;
+	};
 };
 
 &pm660l_wled {


### PR DESCRIPTION
these edits
https://github.com/sdm660-mainline/linux/pull/61

work also on tulip.
tested with
```
echo "255" > /sys/class/leds/white:status/brightness
```
downstream instead there are three leds and three echo are required on all nodes to power on the led