### PR TITLE
ath10k: snoc: fix unbalanced IRQ enable in crash recovery

### DIFF
--- a/drivers/net/wireless/ath/ath10k/snoc.c
+++ b/drivers/net/wireless/ath/ath10k/snoc.c
@@ -937,7 +937,9 @@ static int ath10k_snoc_hif_start(struct ath10k *ar)
 
 	dev_set_threaded(ar->napi_dev, true);
 	ath10k_core_napi_enable(ar);
-	ath10k_snoc_irq_enable(ar);
+	/* IRQs are left enabled when we restart due to a firmware crash */
+	if (!test_bit(ATH10K_SNOC_FLAG_RECOVERY, &ar_snoc->flags))
+		ath10k_snoc_irq_enable(ar);
 	ath10k_snoc_rx_post(ar);
 
 	clear_bit(ATH10K_SNOC_FLAG_RECOVERY, &ar_snoc->flags);


### PR DESCRIPTION
From: `Caleb Connolly <caleb.connolly@linaro.org>`

In `ath10k_snoc_hif_stop()` we skip disabling the IRQs in the crash recovery flow, but we still unconditionally call enable again in `ath10k_snoc_hif_start()`.

We can't check the `ATH10K_FLAG_CRASH_FLUSH` bit since it is cleared before `hif_start()` is called, so instead check the `ATH10K_SNOC_FLAG_RECOVERY` flag and skip enabling the IRQs during crash recovery.

This fixes unbalanced IRQ enable splats that happen after recovering from a crash.

Fixes: 0e622f67e041 `("ath10k: add support for WCN3990 firmware crash recovery")`