### PR TITLE
clover: add gpio hall sensor

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -79,6 +79,22 @@
 		};
 	};
 
+	gpio-hall-sensor {
+		compatible = "gpio-keys";
+
+		pinctrl-0 = <&gpio_hall_sensor_default>;
+		pinctrl-names = "default";
+
+		switch {
+			label = "Hall Effect Sensor";
+			gpios = <&tlmm 75 GPIO_ACTIVE_LOW>;
+			linux,input-type = <EV_SW>;
+			linux,code = <SW_LID>;
+			linux,can-disable;
+			wakeup-source;
+		};
+	};
+
 	reserved-memory {
 		#address-cells = <2>;
 		#size-cells = <2>;
@@ -589,6 +605,13 @@
 		function = "mdp_vsync";
 		drive-strength = <2>;
 		bias-pull-down;
+	};
+
+	gpio_hall_sensor_default: gpio-hall-sensor-default-state {
+		pins = "gpio75";
+		function = "gpio";
+		drive-strength = <6>;
+		bias-pull-up;
 	};
 };
 


### PR DESCRIPTION
Seems to work on clover-plus and doesn't cause any new dtbs_check warnings