### PR TITLE
fix "sticky" volume_up button on devices

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-nokia-pl2.dts
+++ b/arch/arm64/boot/dts/qcom/sdm630-nokia-pl2.dts
@@ -8,6 +8,7 @@
 #include "sdm630.dtsi"
 #include "pm660.dtsi"
 #include "pm660l.dtsi"
+#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
 
 / {
 	chassis-type = "handset";
@@ -159,7 +160,10 @@
 	
 	gpio-keys {
 		compatible = "gpio-keys";
-		
+
+		pinctrl-0 = <&vol_up_default>;
+		pinctrl-names = "default";
+
 		key-voldown {
 			label = "Volume Down";
 			gpios = <&pm660l_gpios 7 GPIO_ACTIVE_LOW>;
@@ -295,6 +299,16 @@
 
 &pm660_rradc {
 	status = "okay";
+};
+
+&pm660l_gpios {
+	vol_up_default: vol-up-default-state {
+		pins = "gpio7";
+		function = PMIC_GPIO_FUNC_NORMAL;
+		bias-pull-up;
+		input-enable;
+		qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
+	};
 };
 
 &pon_pwrkey {

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -10,6 +10,7 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/input/gpio-keys.h>
 #include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
 
 / {
 	model = "Xiaomi Redmi Note 6 Pro";
@@ -64,6 +65,9 @@
 
 	gpio-keys {
 		compatible = "gpio-keys";
+
+		pinctrl-0 = <&vol_up_default>;
+		pinctrl-names = "default";
 
 		key-volup {
 			label = "Volume Up";
@@ -244,6 +248,16 @@
 
 &pm660_rradc {
 	status = "okay";
+};
+
+&pm660l_gpios {
+	vol_up_default: vol-up-default-state {
+		pins = "gpio7";
+		function = PMIC_GPIO_FUNC_NORMAL;
+		bias-pull-up;
+		input-enable;
+		qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
+	};
 };
 
 &pm660l_lpg {

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -71,8 +71,11 @@
 	gpio-keys {
 		compatible = "gpio-keys";
 
+		pinctrl-0 = <&vol_up_default>;
+		pinctrl-names = "default";
+
 		key-volup {
-			label = "Volume up";
+			label = "Volume Up";
 			gpios = <&pm660l_gpios 7 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_VOLUMEUP>;
 			debounce-interval = <15>;
@@ -194,6 +197,14 @@
 		pins = "gpio5";
 		function = PMIC_GPIO_FUNC_NORMAL;
 		bias-disable;
+	};
+
+	vol_up_default: vol-up-default-state {
+		pins = "gpio7";
+		function = PMIC_GPIO_FUNC_NORMAL;
+		bias-pull-up;
+		input-enable;
+		qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
@@ -10,6 +10,7 @@
 #include "pm660l.dtsi"
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/input/gpio-keys.h>
+#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
 
 / {
 	model = "Xiaomi Mi A2";
@@ -75,6 +76,9 @@
 
 	gpio-keys {
 		compatible = "gpio-keys";
+
+		pinctrl-0 = <&vol_up_default>;
+		pinctrl-names = "default";
 
 		key-volup {
 			label = "Volume Up";
@@ -229,6 +233,16 @@
 
 &pm660_rradc {
 	status = "okay";
+};
+
+&pm660l_gpios {
+	vol_up_default: vol-up-default-state {
+		pins = "gpio7";
+		function = PMIC_GPIO_FUNC_NORMAL;
+		bias-pull-up;
+		input-enable;
+		qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
+	};
 };
 
 &pm660l_wled {

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
@@ -12,6 +12,7 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/input/gpio-keys.h>
 #include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
 
 /delete-node/ &zap_shader_region;
 
@@ -79,6 +80,9 @@
 
 	gpio-keys {
 		compatible = "gpio-keys";
+
+		pinctrl-0 = <&vol_up_default>;
+		pinctrl-names = "default";
 
 		key-volup {
 			label = "Volume Up";
@@ -219,6 +223,16 @@
 
 &pm660_rradc {
 	status = "okay";
+};
+
+&pm660l_gpios {
+	vol_up_default: vol-up-default-state {
+		pins = "gpio7";
+		function = PMIC_GPIO_FUNC_NORMAL;
+		bias-pull-up;
+		input-enable;
+		qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
+	};
 };
 
 &pm660l_lpg {


### PR DESCRIPTION
Electrical pin properties configuration was missing, leading to incorrect bias/pull and possibly input/output mode.

Before fix:
```
# grep gpio7 /sys/kernel/debug/gpio
gpiochip2: GPIOs 639-650, parent: platform/800f000.spmi:pmic@2:gpio@c000, 800f000.spmi:pmic@2:gpio@c000:
 gpio7 : in   high normal  vin-0 no pull                     push-pull  no      atest-1 dtest-0
```

After fix:
```
 gpio7 : in   high normal  vin-0 pull-up 30uA                push-pull  no      atest-1 dtest-0
```

:anger: 