### PR TITLE
6.14 jasmine fixup

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
@@ -123,7 +123,7 @@
 };
 
 &adreno_gpu_zap {
-	firmware-name = "qcom/a512_zap.mdt";
+	firmware-name = "a512_zap.mbn";
 };
 
 &blsp1_uart2 {


### PR DESCRIPTION
specify the correct zap firmware-name for adreno