### PR TITLE
fixup! arm64: dts: qcom: Add initial support for asus-x00td

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
@@ -184,7 +184,7 @@
 
 &adreno_gpu_zap {
 	memory-region = <&zap_shader_region>;
-	firmware-name = "qcom/a512_zap.mdt";
+	firmware-name = "a512_zap.mbn";
 };
 
 &adsp_pil {


### PR DESCRIPTION
adapt firmware-name change to load `a512_zap.mbn`  for gpu

https://gitlab.postmarketos.org/postmarketOS/pmaports/-/blob/master/device/testing/firmware-asus-x00td/APKBUILD#L30