### PR TITLE
A508/509/512 gpucc and speedbins rework

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -597,8 +597,8 @@
 			};
 
 			gpu_speed_bin: gpu-speed-bin@41a0 {
-				reg = <0x41a2 0x1>;
-				bits = <5 7>;
+				reg = <0x41a2 0x2>;
+				bits = <5 8>;
 			};
 		};
 

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -1125,44 +1125,75 @@
 
 			gpu_sdm630_opp_table: opp-table {
 				compatible = "operating-points-v2";
+
+				/*
+				 * 775MHz is only available on default speed bin
+				 * or 162 (bit 3). Though it cannot be used for now
+				 * due to interconnect framework not supporting
+				 * multiple frequencies at the same opp-level.
+				 *
 				opp-775000000 {
 					opp-hz = /bits/ 64 <775000000>;
 					opp-level = <RPM_SMD_LEVEL_TURBO>;
 					opp-peak-kBps = <5412000>;
-					opp-supported-hw = <0xa2>;
+					opp-supported-hw = <0x8>;
+				}; */
+
+				/* bins 162, 146 -> bits 3, 2 */
+				opp-700000000 {
+					opp-hz = /bits/ 64 <700000000>;
+					opp-level = <RPM_SMD_LEVEL_TURBO>;
+					opp-peak-kBps = <5184000>;
+					opp-supported-hw = <0xc>;
 				};
+
+				/* bins 162, 146, 135 -> bits 3, 2, 1 */
 				opp-647000000 {
 					opp-hz = /bits/ 64 <647000000>;
 					opp-level = <RPM_SMD_LEVEL_NOM_PLUS>;
 					opp-peak-kBps = <4068000>;
-					opp-supported-hw = <0xff>;
+					opp-supported-hw = <0xe>;
 				};
+
+				/* 588 MHz and below are supported by all bins */
 				opp-588000000 {
 					opp-hz = /bits/ 64 <588000000>;
 					opp-level = <RPM_SMD_LEVEL_NOM>;
 					opp-peak-kBps = <3072000>;
 					opp-supported-hw = <0xff>;
 				};
+
 				opp-465000000 {
 					opp-hz = /bits/ 64 <465000000>;
 					opp-level = <RPM_SMD_LEVEL_SVS_PLUS>;
 					opp-peak-kBps = <2724000>;
 					opp-supported-hw = <0xff>;
 				};
+
 				opp-370000000 {
 					opp-hz = /bits/ 64 <370000000>;
 					opp-level = <RPM_SMD_LEVEL_SVS>;
 					opp-peak-kBps = <2188000>;
 					opp-supported-hw = <0xff>;
 				};
+
 				opp-240000000 {
 					opp-hz = /bits/ 64 <240000000>;
 					opp-level = <RPM_SMD_LEVEL_LOW_SVS>;
 					opp-peak-kBps = <1648000>;
 					opp-supported-hw = <0xff>;
 				};
+
 				opp-160000000 {
 					opp-hz = /bits/ 64 <160000000>;
+					opp-level = <RPM_SMD_LEVEL_MIN_SVS>;
+					opp-peak-kBps = <1200000>;
+					opp-supported-hw = <0xff>;
+				};
+
+				/* Idle, parented to gpucc_cxo */
+				opp-19200000 {
+					opp-hz = /bits/ 64 <19200000>;
 					opp-level = <RPM_SMD_LEVEL_MIN_SVS>;
 					opp-peak-kBps = <1200000>;
 					opp-supported-hw = <0xff>;

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -1125,20 +1125,6 @@
 
 			gpu_sdm630_opp_table: opp-table {
 				compatible = "operating-points-v2";
-
-				opp-700000000 {
-					opp-hz = /bits/ 64 <700000000>;
-					opp-level = <RPM_SMD_LEVEL_TURBO>;
-					opp-peak-kBps = <5184000>;
-					opp-supported-hw = <0xFF>;
-				};
-
-				/*
-				* 775MHz is only available on default speed bin
-				* or 0xA2 (speed bin 1). Though it cannot be used
-				* for now due to interconnect framework not supporting
-				* multiple frequencies at the same opp-level
-
 				opp-775000000 {
 					opp-hz = /bits/ 64 <775000000>;
 					opp-level = <RPM_SMD_LEVEL_TURBO>;
@@ -1181,7 +1167,6 @@
 					opp-peak-kBps = <1200000>;
 					opp-supported-hw = <0xff>;
 				};
-				*/
 			};
 
 			adreno_gpu_zap: zap-shader {

--- a/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
@@ -172,14 +172,6 @@
 
 &adreno_gpu {
 	status = "okay";
-
-	// These OPPs are correct, but we are lacking support for the
-	// GPU regulator. Hence, disable them for now to prevent the
-	// platform from hanging on high graphics loads
-	opp-table {
-		/delete-node/ opp-700000000;
-		/delete-node/ opp-266000000;
-	};
 };
 
 &adreno_gpu_zap {

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -110,23 +110,6 @@
 
 &adreno_gpu {
 	status = "okay";
-
-	opp-table {
-		/delete-node/ opp-700000000;
-
-		opp-430000000 {
-			opp-hz = /bits/ 64 <430000000>;
-			opp-level = <RPM_SMD_LEVEL_SVS_PLUS>;
-			opp-supported-hw = <0xff>;
-		};
-
-		opp-370000000 {
-			opp-hz = /bits/ 64 <370000000>;
-			opp-level = <RPM_SMD_LEVEL_SVS>;
-			opp-peak-kBps = <2188000>;
-			opp-supported-hw = <0xff>;
-		};
-	};
 };
 
 &adreno_gpu_zap {

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-whyred.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-whyred.dts
@@ -156,25 +156,6 @@
 
 &adreno_gpu {
 	status = "okay";
-
-	/* Limit GPU frequencies to lowest to allow it to probe somehow */
-	opp-table {
-		/delete-node/ opp-700000000;
-
-		opp-430000000 {
-			opp-hz = /bits/ 64 <430000000>;
-			opp-level = <RPM_SMD_LEVEL_SVS_PLUS>;
-			opp-peak-kBps = <2724000>;
-			opp-supported-hw = <0xff>;
-		};
-
-		opp-370000000 {
-			opp-hz = /bits/ 64 <370000000>;
-			opp-level = <RPM_SMD_LEVEL_SVS>;
-			opp-peak-kBps = <2188000>;
-			opp-supported-hw = <0xff>;
-		};
-	};
 };
 
 &adreno_gpu_zap {

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -13,61 +13,82 @@
 	compatible = "qcom,adreno-512.0", "qcom,adreno";
 	operating-points-v2 = <&gpu_sdm660_opp_table>;
 
+	/*
+	 * Delete the whole OPP table inherited from SDM630 - we need to
+	 * rewrite it cleanly from scratch, because frequency tables in gpucc
+	 * are different between sdm630 - sdm660, and the same bin (135) has
+	 * different meaning (unlocks different frequencies) on sdm660,
+	 * compared to sdm630.
+	 */
+	/delete-node/ opp-table;
+
 	gpu_sdm660_opp_table: opp-table {
 		compatible = "operating-points-v2";
 
 		/*
-		 * 775MHz is only available on the highest speed bin
+		 * 750 MHz is only available on the highest speed bin
 		 * Though it cannot be used for now due to interconnect
 		 * framework not supporting multiple frequencies
-		 * at the same opp-level
+		 * at the same opp-level.
+		 * These OPPs are correct, but we are lacking support for the
+		 * GPU regulator. Hence, disable them for now to prevent the
+		 * platform from hanging on high graphics loads.
 
+		 * bin 157 -> bit 6 *
 		opp-750000000 {
 			opp-hz = /bits/ 64 <750000000>;
 			opp-level = <RPM_SMD_LEVEL_TURBO>;
 			opp-peak-kBps = <5412000>;
-			opp-supported-hw = <0xCHECKME>;
-		};
+			opp-supported-hw = <0x40>;
+		}; */
 
-		* These OPPs are correct, but we are lacking support for the
-		* GPU regulator. Hence, disable them for now to prevent the
-		* platform from hanging on high graphics loads.
-
+		/* bins 157,146 -> bits 6,5 */
 		opp-700000000 {
 			opp-hz = /bits/ 64 <700000000>;
 			opp-level = <RPM_SMD_LEVEL_TURBO>;
 			opp-peak-kBps = <5184000>;
-			opp-supported-hw = <0xff>;
+			opp-supported-hw = <0x60>;
 		};
 
+		/* bins 157,146,135 -> bits 6,5,4 */
 		opp-647000000 {
 			opp-hz = /bits/ 64 <647000000>;
 			opp-level = <RPM_SMD_LEVEL_NOM_PLUS>;
 			opp-peak-kBps = <4068000>;
-			opp-supported-hw = <0xff>;
+			opp-supported-hw = <0x70>;
 		};
 
+		/* bins 157,146,135 -> bits 6,5,4 */
 		opp-588000000 {
 			opp-hz = /bits/ 64 <588000000>;
 			opp-level = <RPM_SMD_LEVEL_NOM>;
 			opp-peak-kBps = <3072000>;
-			opp-supported-hw = <0xff>;
+			opp-supported-hw = <0x70>;
 		};
 
+		/* bins 157,146,135,122 -> bits 6,5,4,3 */
 		opp-465000000 {
 			opp-hz = /bits/ 64 <465000000>;
 			opp-level = <RPM_SMD_LEVEL_SVS_PLUS>;
 			opp-peak-kBps = <2724000>;
-			opp-supported-hw = <0xff>;
+			opp-supported-hw = <0x78>;
 		};
 
+		/* this one is for SDM636 with bin 90, bit 2 */
+		opp-430000000 {
+			opp-hz = /bits/ 64 <430000000>;
+			opp-level = <RPM_SMD_LEVEL_SVS_PLUS>;
+			opp-peak-kBps = <2724000>;
+			opp-supported-hw = <0x4>;
+		};
+
+		/* 370 MHz and below are supported in all bins */
 		opp-370000000 {
 			opp-hz = /bits/ 64 <370000000>;
 			opp-level = <RPM_SMD_LEVEL_SVS>;
 			opp-peak-kBps = <2188000>;
 			opp-supported-hw = <0xff>;
 		};
-		*/
 
 		opp-266000000 {
 			opp-hz = /bits/ 64 <266000000>;
@@ -78,6 +99,14 @@
 
 		opp-160000000 {
 			opp-hz = /bits/ 64 <160000000>;
+			opp-level = <RPM_SMD_LEVEL_MIN_SVS>;
+			opp-peak-kBps = <1200000>;
+			opp-supported-hw = <0xff>;
+		};
+
+		/* Idle, parented to gpucc_cxo */
+		opp-19200000 {
+			opp-hz = /bits/ 64 <19200000>;
 			opp-level = <RPM_SMD_LEVEL_MIN_SVS>;
 			opp-peak-kBps = <1200000>;
 			opp-supported-hw = <0xff>;

--- a/drivers/clk/qcom/clk-rcg.h
+++ b/drivers/clk/qcom/clk-rcg.h
@@ -198,6 +198,7 @@ extern const struct clk_ops clk_byte_ops;
 extern const struct clk_ops clk_byte2_ops;
 extern const struct clk_ops clk_pixel_ops;
 extern const struct clk_ops clk_gfx3d_ops;
+extern const struct clk_ops clk_gfx3d_src_ops;
 extern const struct clk_ops clk_rcg2_shared_ops;
 extern const struct clk_ops clk_rcg2_shared_floor_ops;
 extern const struct clk_ops clk_rcg2_shared_no_init_park_ops;

--- a/drivers/clk/qcom/clk-rcg2.c
+++ b/drivers/clk/qcom/clk-rcg2.c
@@ -1318,6 +1318,113 @@ const struct clk_ops clk_gfx3d_ops = {
 };
 EXPORT_SYMBOL_GPL(clk_gfx3d_ops);
 
+static int clk_gfx3d_src_determine_rate(struct clk_hw *hw,
+					struct clk_rate_request *req)
+{
+	struct clk_rate_request parent_req = { .min_rate = 0, .max_rate = ULONG_MAX };
+	struct clk_rcg2_gfx3d *cgfx = to_clk_rcg2_gfx3d(hw);
+	struct clk_rcg2 *rcg = &cgfx->rcg;
+	struct clk_hw *xo, *p0, *p1, *curr_p;
+	const struct freq_tbl *f;
+	int ret;
+
+	xo = clk_hw_get_parent_by_index(hw, 0);
+	/*
+	 * When msm_gpu devfreq wants to put GPU to idle, it requests the rate
+	 * of 27 MHz (27000000) in function disable_clk() in
+	 * drivers/gpu/drm/msm/msm_gpu.c. It expects "rounding down to zero".
+	 * Check for any request below 30 MHz here and round it down to lowest:
+	 */
+	if (req->rate < 30000000) {
+		req->best_parent_hw = xo;
+		/* return 19.2 MHz even for 27 MHz requests */
+		req->best_parent_rate = clk_hw_get_rate(xo);
+		return 0;
+	}
+
+	f = qcom_find_freq(rcg->freq_tbl, req->rate);
+	if (!f || (req->rate != f->freq))
+		return -EINVAL;
+
+	/* Indexes of source from the parent map */
+	p0 = clk_hw_get_parent_by_index(hw, 1);
+	p1 = clk_hw_get_parent_by_index(hw, 2);
+
+	curr_p = clk_hw_get_parent(hw);
+
+	parent_req.rate = f->freq * (f->pre_div + 1) / 2;
+
+	if (curr_p == xo || curr_p == p1)
+		req->best_parent_hw = p0;
+	else if (curr_p == p0)
+		req->best_parent_hw = p1;
+
+	parent_req.best_parent_hw = clk_hw_get_parent(req->best_parent_hw);
+	parent_req.best_parent_rate = clk_hw_get_rate(parent_req.best_parent_hw);
+
+
+	ret = __clk_determine_rate(req->best_parent_hw, &parent_req);
+	if (ret)
+		return ret;
+
+	clk_hw_get_rate_range(req->best_parent_hw,
+	&parent_req.min_rate, &parent_req.max_rate);
+
+	if (req->min_rate > parent_req.min_rate)
+		parent_req.min_rate = req->min_rate;
+
+	if (req->max_rate < parent_req.max_rate)
+		parent_req.max_rate = req->max_rate;
+
+	req->best_parent_rate = parent_req.rate;
+
+	return 0;
+}
+
+static int clk_gfx3d_src_set_rate_and_parent(struct clk_hw *hw, unsigned long rate,
+					     unsigned long parent_rate, u8 index)
+{
+	struct clk_rcg2_gfx3d *cgfx = to_clk_rcg2_gfx3d(hw);
+	struct clk_rcg2 *rcg = &cgfx->rcg;
+	const struct freq_tbl *f;
+	u32 cfg;
+	int ret;
+
+	cfg = rcg->parent_map[index].cfg << CFG_SRC_SEL_SHIFT;
+
+	/*
+	 * For "idle" requests use parent_rate, which will be cxo rate of
+	 * 19.2 MHz, so that qcom_find_freq() call below can find the
+	 * actual correct entry in freq_tbl with the correct divider set.
+	 */
+	if (rate < 30000000)
+		rate = 19200000;
+
+	f = qcom_find_freq(rcg->freq_tbl, rate);
+	if (!f)
+		return -EINVAL;
+
+	/* Update the RCG-DIV */
+	cfg |= f->pre_div << CFG_SRC_DIV_SHIFT;
+
+	ret = regmap_write(rcg->clkr.regmap, rcg->cmd_rcgr + CFG_REG, cfg);
+	if (ret)
+		return ret;
+
+	return update_config(rcg);
+}
+
+const struct clk_ops clk_gfx3d_src_ops = {
+	.is_enabled = clk_rcg2_is_enabled,
+	.get_parent = clk_rcg2_get_parent,
+	.set_parent = clk_rcg2_set_parent,
+	.recalc_rate = clk_rcg2_recalc_rate,
+	.set_rate = clk_gfx3d_set_rate,
+	.set_rate_and_parent = clk_gfx3d_src_set_rate_and_parent,
+	.determine_rate = clk_gfx3d_src_determine_rate,
+};
+EXPORT_SYMBOL_GPL(clk_gfx3d_src_ops);
+
 static int clk_rcg2_set_force_enable(struct clk_hw *hw)
 {
 	struct clk_rcg2 *rcg = to_clk_rcg2(hw);

--- a/drivers/clk/qcom/gpucc-sdm660.c
+++ b/drivers/clk/qcom/gpucc-sdm660.c
@@ -20,7 +20,6 @@
 #include "clk-alpha-pll.h"
 #include "common.h"
 #include "clk-regmap.h"
-#include "clk-pll.h"
 #include "clk-rcg.h"
 #include "clk-branch.h"
 #include "gdsc.h"
@@ -101,18 +100,65 @@ static const struct clk_parent_data gpucc_parent_data_1[] = {
 	{ .fw_name = "gcc_gpu_gpll0_clk" },
 };
 
+/*
+ * Frequencies and PLL configuration
+ * The PLL source would be doing ping-pong between
+ * GPU-PLL0 and GPU-PLL1.
+ *  ====================================================
+ *  | F         | PLL SRC Freq | PLL postdiv | RCG Div |
+ *  ====================================================
+ *  | 160000000 | 640000000    |    2        |    2    |
+ *  | 266000000 | 532000000    |    1        |    2    |
+ *  | 370000000 | 740000000    |    1        |    2    |
+ *  | 465000000 | 930000000    |    1        |    2    |
+ *  | 588000000 | 1176000000   |    1        |    2    |
+ *  | 647000000 | 1294000000   |    1        |    2    |
+ *  | 700000000 | 1400000000   |    1        |    2    |
+ *  | 750000000 | 1500000000   |    1        |    2    |
+ *  ====================================================
+*/
+
+static const struct freq_tbl ftbl_gfx3d_clk_src_660[] = {
+	F( 19200000, 0,  1, 0, 0),
+	F(160000000, 0,  4, 0, 0),
+	F(266000000, 0,  2, 0, 0),
+	F(370000000, 0,  2, 0, 0),
+	F(430000000, 0,  2, 0, 0),
+	F(465000000, 0,  2, 0, 0),
+	F(585000000, 0,  2, 0, 0),
+	F(588000000, 0,  2, 0, 0),
+	F(647000000, 0,  2, 0, 0),
+	F(700000000, 0,  2, 0, 0),
+	F(750000000, 0,  2, 0, 0),
+	{ }
+};
+
+static const struct freq_tbl ftbl_gfx3d_clk_src_630[] = {
+	F( 19200000, 0,  1, 0, 0),
+	F(160000000, 0,  4, 0, 0),
+	F(240000000, 0,  2, 0, 0),
+	F(370000000, 0,  2, 0, 0),
+	F(465000000, 0,  2, 0, 0),
+	F(588000000, 0,  2, 0, 0),
+	F(647000000, 0,  2, 0, 0),
+	F(648000000, 0,  2, 0, 0),
+	F(700000000, 0,  2, 0, 0),
+	F(775000000, 0,  2, 0, 0),
+	{ }
+};
+
 static struct clk_rcg2_gfx3d gfx3d_clk_src = {
-	.div = 2,
 	.rcg = {
 		.cmd_rcgr = 0x1070,
 		.mnd_width = 0,
 		.hid_width = 5,
 		.parent_map = gpucc_parent_map_1,
+		.freq_tbl = ftbl_gfx3d_clk_src_660,
 		.clkr.hw.init = &(struct clk_init_data){
 			.name = "gfx3d_clk_src",
 			.parent_data = gpucc_parent_data_1,
 			.num_parents = ARRAY_SIZE(gpucc_parent_data_1),
-			.ops = &clk_gfx3d_ops,
+			.ops = &clk_gfx3d_src_ops,
 			.flags = CLK_SET_RATE_PARENT | CLK_OPS_PARENT_ENABLE,
 		},
 	},
@@ -307,27 +353,28 @@ MODULE_DEVICE_TABLE(of, gpucc_sdm660_match_table);
 static int gpucc_sdm660_probe(struct platform_device *pdev)
 {
 	struct regmap *regmap;
-	struct alpha_pll_config gpu_pll_config = {
+	/* 800MHz configuration for GPU PLLs */
+	const struct alpha_pll_config gpu_pll_config = {
 		.config_ctl_val = 0x4001055b,
 		.alpha = 0xaaaaab00,
 		.alpha_en_mask = BIT(24),
 		.vco_val = 0x2 << 20,
 		.vco_mask = 0x3 << 20,
 		.main_output_mask = 0x1,
+		.l = 0x29,
+		.alpha_hi = 0xaa,
 	};
+
+	/* SDM630 uses slightly different frequency table */
+	if (of_device_is_compatible(pdev->dev.of_node, "qcom,gpucc-sdm630"))
+		gfx3d_clk_src.rcg.freq_tbl = ftbl_gfx3d_clk_src_630;
 
 	regmap = qcom_cc_map(pdev, &gpucc_sdm660_desc);
 	if (IS_ERR(regmap))
 		return PTR_ERR(regmap);
 
-	/* 800MHz configuration for GPU PLL0 */
-	gpu_pll_config.l = 0x29;
-	gpu_pll_config.alpha_hi = 0xaa;
+	/* Apply initial 800 MHz configuration for both GPU PLLs */
 	clk_alpha_pll_configure(&gpu_pll0_pll_out_main, regmap, &gpu_pll_config);
-
-	/* 740MHz configuration for GPU PLL1 */
-	gpu_pll_config.l = 0x26;
-	gpu_pll_config.alpha_hi = 0x8a;
 	clk_alpha_pll_configure(&gpu_pll1_pll_out_main, regmap, &gpu_pll_config);
 
 	return qcom_cc_really_probe(&pdev->dev, &gpucc_sdm660_desc, regmap);

--- a/drivers/gpu/drm/msm/adreno/a5xx_catalog.c
+++ b/drivers/gpu/drm/msm/adreno/a5xx_catalog.c
@@ -57,6 +57,12 @@ static const struct adreno_info a5xx_gpus[] = {
 		.quirks = ADRENO_QUIRK_LMLOADKILL_DISABLE,
 		.init = a5xx_gpu_init,
 		.zapfw = "a508_zap.mdt",
+		.speedbins = ADRENO_SPEEDBINS(
+			{  0, 3}, /* default bin, same as 162 one */
+			{135, 1}, /* up to 647 MHz */
+			{146, 2}, /* up to 700 MHz */
+			{162, 3}, /* up to 775 MHz */
+		),
 	}, {
 		.chip_ids = ADRENO_CHIP_IDS(0x05000900),
 		.family = ADRENO_5XX,
@@ -75,6 +81,15 @@ static const struct adreno_info a5xx_gpus[] = {
 		.init = a5xx_gpu_init,
 		/* Adreno 509 uses the same ZAP as 512 */
 		.zapfw = "a512_zap.mdt",
+		.speedbins = ADRENO_SPEEDBINS(
+			{  0, 6}, /* default bin, same as 157 one */
+			{ 78, 1}, /* up to 370 MHz */
+			{ 90, 2}, /* up to 430 MHz */
+			{122, 3}, /* up to 585 MHz */
+			{135, 4}, /* up to 647 MHz */
+			{146, 5}, /* up to 700 MHz */
+			{157, 6}, /* up to 750 MHz */
+		),
 	}, {
 		.chip_ids = ADRENO_CHIP_IDS(0x05010000),
 		.family = ADRENO_5XX,
@@ -107,6 +122,15 @@ static const struct adreno_info a5xx_gpus[] = {
 		.quirks = ADRENO_QUIRK_LMLOADKILL_DISABLE,
 		.init = a5xx_gpu_init,
 		.zapfw = "a512_zap.mdt",
+		.speedbins = ADRENO_SPEEDBINS(
+			{  0, 6}, /* default bin, same as 157 one */
+			{ 78, 1}, /* up to 370 MHz */
+			{ 90, 2}, /* up to 430 MHz */
+			{122, 3}, /* up to 585 MHz */
+			{135, 4}, /* up to 647 MHz */
+			{146, 5}, /* up to 700 MHz */
+			{157, 6}, /* up to 750 MHz */
+		),
 	}, {
 		.chip_ids = ADRENO_CHIP_IDS(
 			0x05030002,

--- a/drivers/gpu/drm/msm/adreno/a5xx_debugfs.c
+++ b/drivers/gpu/drm/msm/adreno/a5xx_debugfs.c
@@ -138,7 +138,21 @@ reset_set(void *data, u64 val)
 	return 0;
 }
 
+static int speedbin_get(void *data, u64 *val)
+{
+	struct drm_device *dev = data;
+	struct msm_drm_private *priv = dev->dev_private;
+	struct msm_gpu *gpu = priv->gpu;
+	struct adreno_gpu *adreno_gpu = to_adreno_gpu(gpu);
+
+	if (val)
+		*val = adreno_gpu->speedbin;
+
+	return 0;
+}
+
 DEFINE_DEBUGFS_ATTRIBUTE(reset_fops, NULL, reset_set, "%llx\n");
+DEFINE_DEBUGFS_ATTRIBUTE(speedbin_fops, speedbin_get, NULL, "%llu\n");
 
 
 void a5xx_debugfs_init(struct msm_gpu *gpu, struct drm_minor *minor)
@@ -156,4 +170,6 @@ void a5xx_debugfs_init(struct msm_gpu *gpu, struct drm_minor *minor)
 
 	debugfs_create_file_unsafe("reset", S_IWUGO, minor->debugfs_root, dev,
 				&reset_fops);
+	debugfs_create_file_unsafe("speedbin", S_IRUGO, minor->debugfs_root, dev,
+				&speedbin_fops);
 }

--- a/drivers/gpu/drm/msm/adreno/a5xx_gpu.c
+++ b/drivers/gpu/drm/msm/adreno/a5xx_gpu.c
@@ -1771,7 +1771,24 @@ struct msm_gpu *a5xx_gpu_init(struct drm_device *dev)
 
 	a5xx_gpu->lm_leakage = 0x4E001A;
 
-	check_speed_bin(&pdev->dev);
+	/*
+	 * The switch to a new method requires porting over affected device
+	 * trees (changing opp-supported-hw to use bits from ADRENO_SPEEDBINS).
+	 * Use the new method for those that were ported so far, while keeping
+	 * the old way (check_speed_bin) until the rest platforms (a530, a540)
+	 * are ported too.
+	 */
+	if (of_machine_is_compatible("qcom,sdm630") ||
+	    of_machine_is_compatible("qcom,sdm636") ||
+	    of_machine_is_compatible("qcom,sdm660")) {
+		ret = adreno_set_supported_hw(&pdev->dev, config->info);
+		if (ret) {
+			dev_err(&pdev->dev, "Failed to set opp-supported-hw: %d\n", ret);
+			return ERR_PTR(ret);
+		}
+	} else {
+		check_speed_bin(&pdev->dev);
+	}
 
 	nr_rings = 4;
 

--- a/drivers/gpu/drm/msm/adreno/a6xx_gpu.c
+++ b/drivers/gpu/drm/msm/adreno/a6xx_gpu.c
@@ -2308,53 +2308,6 @@ static bool a6xx_progress(struct msm_gpu *gpu, struct msm_ringbuffer *ring)
 	return progress;
 }
 
-static u32 fuse_to_supp_hw(const struct adreno_info *info, u32 fuse)
-{
-	if (!info->speedbins)
-		return UINT_MAX;
-
-	for (int i = 0; info->speedbins[i].fuse != SHRT_MAX; i++)
-		if (info->speedbins[i].fuse == fuse)
-			return BIT(info->speedbins[i].speedbin);
-
-	return UINT_MAX;
-}
-
-static int a6xx_set_supported_hw(struct device *dev, const struct adreno_info *info)
-{
-	u32 supp_hw;
-	u32 speedbin;
-	int ret;
-
-	ret = adreno_read_speedbin(dev, &speedbin);
-	/*
-	 * -ENOENT means that the platform doesn't support speedbin which is
-	 * fine
-	 */
-	if (ret == -ENOENT) {
-		return 0;
-	} else if (ret) {
-		dev_err_probe(dev, ret,
-			      "failed to read speed-bin. Some OPPs may not be supported by hardware\n");
-		return ret;
-	}
-
-	supp_hw = fuse_to_supp_hw(info, speedbin);
-
-	if (supp_hw == UINT_MAX) {
-		DRM_DEV_ERROR(dev,
-			"missing support for speed-bin: %u. Some OPPs may not be supported by hardware\n",
-			speedbin);
-		supp_hw = BIT(0); /* Default */
-	}
-
-	ret = devm_pm_opp_set_supported_hw(dev, &supp_hw, 1);
-	if (ret)
-		return ret;
-
-	return 0;
-}
-
 static const struct adreno_gpu_funcs funcs = {
 	.base = {
 		.get_param = adreno_get_param,
@@ -2487,7 +2440,7 @@ struct msm_gpu *a6xx_gpu_init(struct drm_device *dev)
 
 	a6xx_llc_slices_init(pdev, a6xx_gpu, is_a7xx);
 
-	ret = a6xx_set_supported_hw(&pdev->dev, config->info);
+	ret = adreno_set_supported_hw(&pdev->dev, config->info);
 	if (ret) {
 		a6xx_llc_slices_destroy(a6xx_gpu);
 		kfree(a6xx_gpu);

--- a/drivers/gpu/drm/msm/adreno/adreno_gpu.c
+++ b/drivers/gpu/drm/msm/adreno/adreno_gpu.c
@@ -1116,6 +1116,8 @@ int adreno_set_supported_hw(struct device *dev, const struct adreno_info *info)
 	}
 
 	supp_hw = fuse_to_supp_hw(info, speedbin);
+	dev_info(dev, "GPU speedbin fuse %d (0x%x), mapped to opp-supp-hw 0x%x\n",
+		 speedbin, speedbin, supp_hw);
 
 	if (supp_hw == UINT_MAX) {
 		DRM_DEV_ERROR(dev,

--- a/drivers/gpu/drm/msm/adreno/adreno_gpu.c
+++ b/drivers/gpu/drm/msm/adreno/adreno_gpu.c
@@ -1085,6 +1085,52 @@ int adreno_read_speedbin(struct device *dev, u32 *speedbin)
 	return nvmem_cell_read_variable_le_u32(dev, "speed_bin", speedbin);
 }
 
+static u32 fuse_to_supp_hw(const struct adreno_info *info, u32 fuse)
+{
+	if (!info->speedbins)
+		return UINT_MAX;
+
+	for (int i = 0; info->speedbins[i].fuse != SHRT_MAX; i++)
+		if (info->speedbins[i].fuse == fuse)
+			return BIT(info->speedbins[i].speedbin);
+
+	return UINT_MAX;
+}
+
+int adreno_set_supported_hw(struct device *dev, const struct adreno_info *info)
+{
+	u32 supp_hw;
+	u32 speedbin;
+	int ret;
+
+	ret = adreno_read_speedbin(dev, &speedbin);
+	/*
+	 * -ENOENT means that the platform doesn't support speedbin which is
+	 * fine
+	 */
+	if (ret == -ENOENT) {
+		return 0;
+	} else if (ret) {
+		return dev_err_probe(dev, ret,
+				"failed to read speed-bin. Some OPPs may not be supported by hardware\n");
+	}
+
+	supp_hw = fuse_to_supp_hw(info, speedbin);
+
+	if (supp_hw == UINT_MAX) {
+		DRM_DEV_ERROR(dev,
+			"missing support for speed-bin: %u. Some OPPs may not be supported by hardware\n",
+			speedbin);
+		supp_hw = BIT(0); /* Default */
+	}
+
+	ret = devm_pm_opp_set_supported_hw(dev, &supp_hw, 1);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
 int adreno_gpu_init(struct drm_device *drm, struct platform_device *pdev,
 		struct adreno_gpu *adreno_gpu,
 		const struct adreno_gpu_funcs *funcs, int nr_rings)

--- a/drivers/gpu/drm/msm/adreno/adreno_gpu.h
+++ b/drivers/gpu/drm/msm/adreno/adreno_gpu.h
@@ -631,6 +631,8 @@ int adreno_fault_handler(struct msm_gpu *gpu, unsigned long iova, int flags,
 
 int adreno_read_speedbin(struct device *dev, u32 *speedbin);
 
+int adreno_set_supported_hw(struct device *dev, const struct adreno_info *info);
+
 /*
  * For a5xx and a6xx targets load the zap shader that is used to pull the GPU
  * out of secure mode

--- a/drivers/opp/of.c
+++ b/drivers/opp/of.c
@@ -572,13 +572,16 @@ static bool _opp_is_supported(struct device *dev, struct opp_table *opp_table,
 
 			/* Check if the level is supported */
 			if (!(val & opp_table->supported_hw[j])) {
+				printk(KERN_WARNING "opp not supported: %s (0x%x & 0x%x)\n", np->name, val, opp_table->supported_hw[j]);
 				supported = false;
 				break;
 			}
 		}
 
-		if (supported)
+		if (supported) {
+			printk(KERN_INFO "opp is  supported: %s\n", np->name);
 			return true;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
* Fix reading the speedbins correctly.
* Use `ADRENO_SPEEDBINS` to specify fuses and their corresponding bit shift values in `a5xx_catalog.c`
* Move `a6xx_set_supported_hw()` to common code, renaming it to `adreno_set_supported_hw()`
* Use new common funcs to setup opp-supp-hw on a5xx
* Update sdm630/636/660 SoC device trees to use the correct supp-hw values, uncomment all freqs in opp-table
* Stop doing custom opp-table overrides in individual device `.dts`
* Fix gpucc-sdm660 driver to actually allow switching frequencies, using new dedicated clk_gfx3d_src_ops. Add frequency tables, same way as it's done in downstream

TBD

P.S.
~~* sony-xperia-nile fixes are irrelevant here, should go into separate branch~~
* the last commit "DEBUG drop-me: opp/of: debug prints" should go away
* the revert commit of "gpu go 700mhz" and the revert target commit should be dropped before release 