### PR TITLE
sony-pioneer: add TEAR_MODE_VBLANK to init seq

### DIFF
--- a/drivers/gpu/drm/panel/panel-truly-td4322.c
+++ b/drivers/gpu/drm/panel/panel-truly-td4322.c
@@ -43,6 +43,7 @@ static int truly_td4322_on(struct truly_td4322 *ctx)
 	mipi_dsi_generic_write_seq(dsi, 0xb0, 0x00);
 	mipi_dsi_generic_write_seq(dsi, 0xd5,
 				   0x03, 0x00, 0x00, 0x02, 0x23, 0x02, 0x23);
+	mipi_dsi_dcs_set_tear_on(dsi, MIPI_DSI_DCS_TEAR_MODE_VBLANK);
 
 	ret = mipi_dsi_dcs_set_display_on(dsi);
 	if (ret < 0) {


### PR DESCRIPTION
Inspired by https://github.com/msm8916-mainline/linux-mdss-dsi-panel-driver-generator/pull/37

seems to help, at least doesn't do any harm?