### PR TITLE
[6.14] Fix usb cable insertion causing reset on sdm660-xiaomis

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -485,6 +485,7 @@
 			regulator-max-microvolt = <1950000>;
 			regulator-enable-ramp-delay = <250>;
 			regulator-allow-set-load;
+			regulator-system-load = <14000>;
 		};
 
 		vreg_l11a_1p8: l11 {

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-whyred.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-whyred.dts
@@ -549,6 +549,7 @@
 			regulator-max-microvolt = <1950000>;
 			regulator-enable-ramp-delay = <250>;
 			regulator-allow-set-load;
+			regulator-system-load = <14000>;
 		};
 
 		vreg_l11a_1p8: l11 {

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -496,6 +496,7 @@
 			regulator-enable-ramp-delay = <250>;
 			regulator-ramp-delay = <0>;
 			regulator-allow-set-load;
+			regulator-system-load = <14000>;
 		};
 
 		vreg_l11a_1p8: l11 {

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
@@ -473,6 +473,7 @@
 			regulator-max-microvolt = <1950000>;
 			regulator-enable-ramp-delay = <250>;
 			regulator-allow-set-load;
+			regulator-system-load = <14000>;
 		};
 
 		vreg_l11a_1p8: l11 {

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
@@ -478,6 +478,7 @@
 			regulator-max-microvolt = <1950000>;
 			regulator-enable-ramp-delay = <250>;
 			regulator-allow-set-load;
+			regulator-system-load = <14000>;
 		};
 
 		vreg_l11a_1p8: l11 {

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-platina.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-platina.dts
@@ -573,6 +573,7 @@
 			regulator-enable-ramp-delay = <250>;
 			regulator-ramp-delay = <0>;
 			regulator-allow-set-load;
+			regulator-system-load = <14000>;
 		};
 
 		vreg_l11a_1p8: l11 {


### PR DESCRIPTION
DOwnstream definition for l10a looks like
```c
			rpm-regulator-ldoa10 {
				compatible = "qcom,rpm-smd-regulator-resource";
				qcom,resource-name = "ldoa";
				qcom,resource-id = <0xa>;
				qcom,regulator-type = <0x0>;
				status = "okay";

				regulator-l10 {
					compatible = "qcom,rpm-smd-regulator";
					regulator-name = "pm660_l10";
					qcom,set = <0x3>;
					status = "okay";
					proxy-supply = <0xc9>;
					qcom,proxy-consumer-enable;
					qcom,proxy-consumer-current = <0x36b0>; /* 14000 */
					regulator-min-microvolt = <1780000>;  /* 1.78 V */
					regulator-max-microvolt = <1950000>;  /* 1.95 V */
					linux,phandle = <0xc9>;
					phandle = <0xc9>;
				};
			};
```