### PR TITLE
CI: improvements

### DIFF
--- a/.github/workflows/analyze_dtbs_check.py
+++ b/.github/workflows/analyze_dtbs_check.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python3
+
+import sys
+
+
+IGNORE_ERRORS = [
+    '\'fb-panel\' does not match any of the regexes',
+    '\'framebuffer-panel\' does not match any of the regexes',
+    '\'fuel-gauge@4000\' does not match any of the regexes',
+    'failed to match any schema with compatible: [\'qcom,pmi8998-fg\']',
+]
+
+def is_error_ignored(line: str) -> bool:
+    global IGNORE_ERRORS
+    for ie in IGNORE_ERRORS:
+        if ie in line:
+            return True
+    return False
+
+def short_dtb_path(line: str) -> str:
+    # /home/lexx/dev/kernels/linux/build-660/arch/arm64/boot/dts/qcom/sda660-xiaomi-clover.dtb: /: qcom,board-id: False schema does not allow [[11, 0]]
+    # sda660-xiaomi-clover.dtb: /: qcom,board-id: False schema does not allow [[11, 0]]
+    spos = line.find('.dtb:')
+    if spos == -1:
+        return line
+    parts = line.split('.dtb:')
+    dtb_part = parts[0]
+    errmsg = parts[1]
+    dtb_part = dtb_part.split('/')[-1]
+    return dtb_part + '.dtb:' + errmsg
+
+def main() -> int:
+    if len(sys.argv) < 1:
+        print('Expected results file as an argument')
+        return 1
+
+    results_filename = sys.argv[1]
+
+    errors_count = 0
+    errors_ignored = 0
+
+    error_texts = []
+
+    try:
+        with open(results_filename, 'rt', encoding='utf-8') as f:
+            for line in f.readlines():
+                line = line.strip()
+                if 'from schema $id' in line:
+                    continue
+                if line.startswith('SCHEMA ') or line.startswith('DTC [C]'):
+                    continue
+                errors_count = errors_count + 1
+                if is_error_ignored(line):
+                    errors_ignored = errors_ignored + 1
+                    continue
+                error_texts.append(short_dtb_path(line))
+    except IOError as ex:
+        print(str(ex))
+        errors_count = 1
+
+    errors_left = errors_count - errors_ignored
+    if errors_left > 0:
+        for l in error_texts:
+            print(l)
+    print(f'Errors: {errors_left} ({errors_count} total, {errors_ignored} ignored)')
+    return errors_left
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/workflows/check-dtschema.yml
+++ b/.github/workflows/check-dtschema.yml
@@ -8,8 +8,8 @@ on:
     tags:
       - v*-sdm660
 jobs:
-  check-dbts:
-    runs-on: ubuntu-22.04
+  dbts-check:
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,6 +32,12 @@ jobs:
           python3 -m venv venv_dtschema
           . venv_dtschema/bin/activate
           pip3 install dtschema
-          make O=build-dtbs-check ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- CHECK_DTBS=y qcom/sdm630-*.dtb qcom/sdm636-*.dtb qcom/sdm660-*.dtb qcom/sda660-*.dtb
+          make O=build-dtbs-check ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- -j1 CHECK_DTBS=y \
+              qcom/sdm630-*.dtb qcom/sdm636-*.dtb qcom/sdm660-*.dtb qcom/sda660-*.dtb 2>&1 | \
+              tee build-dtbs-check/results.txt
           deactivate
           rm -r venv_dtschema
+      - name: Analyze results
+        continue-on-error: true
+        run: |
+          python3 .github/workflows/analyze_dtbs_check.py build-dtbs-check/results.txt


### PR DESCRIPTION
dt-validate (and therefore, make CHECK_DTBS) always return 0 exit code!
Even if there are errors. So, some post-processing analyzer step is needed.

* rename step
* Use latest ubuntu image base.
* save dtbs_check results to file to be able to analyze it
* add python script that tries to count how many errors are there in results and even ignores some of them
* use `continue-on-error: true` for now, to still allow it to fail