### PR TITLE
Fix wifi on clover

### DIFF
--- a/arch/arm64/boot/dts/qcom/sda660-xiaomi-clover.dts
+++ b/arch/arm64/boot/dts/qcom/sda660-xiaomi-clover.dts
@@ -7,11 +7,8 @@
 #include "sdm660-xiaomi-clover-common.dtsi"
 
 / {
-	model = "Xiaomi Mi Pad 4";	
+	model = "Xiaomi Mi Pad 4";
 	compatible = "xiaomi,clover", "qcom,sda660";
-	qcom,board-id = <11 0>;
-	qcom,msm-id = <324 0>;
-	qcom,pmic-id = <0x0001001b 0x0101011a 0x0 0x0>, <0x0001001b 0x0201011a 0x0 0x0>,<0x0001001b 0x0102001a 0x0 0x0>;
 };
 
 &blsp_i2c3 {
@@ -76,6 +73,12 @@
 	qcom,switching-freq = <800>;
 	qcom,current-limit-microamp = <20000>;
 	qcom,num-strings = <3>;
+
+	status = "okay";
+};
+
+&remoteproc_mss {
+	firmware-name = "mba.mbn", "modemnm.mdt";
 
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -242,12 +242,6 @@
 	status = "okay";
 };
 
-&remoteproc_mss {
-	firmware-name = "mba.mbn", "modem.mdt";
-
-	status = "okay";
-};
-
 &rpm_requests {
 	regulators-0 {
 		compatible = "qcom,rpm-pm660l-regulators";

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-plus.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-plus.dts
@@ -9,9 +9,6 @@
 / {
 	model = "Xiaomi Mi Pad 4 Plus";
 	compatible = "xiaomi,clover-plus", "qcom,sdm660";
-	qcom,board-id = <11 0>;
-	qcom,msm-id = <324 0>;
-	qcom,pmic-id = <0x0001001b 0x0101011a 0x0 0x0>, <0x0001001b 0x0201011a 0x0 0x0>,<0x0001001b 0x0102001a 0x0 0x0>;
 
 	vreg_bl_vddio: lcd-backlight-regulator {
 		compatible = "regulator-fixed";
@@ -136,6 +133,12 @@
 
 &mdss_dsi0_phy {
 	vcca-supply = <&vreg_l1b_0p925>;
+
+	status = "okay";
+};
+
+&remoteproc_mss {
+	firmware-name = "mba.mbn", "modem.mdt";
 
 	status = "okay";
 };


### PR DESCRIPTION
clover using different modem firmware from clover-plus it is called `modemnm`.

I have done some small clean ups in all clover dt.