### PR TITLE
Small jasmine fixup for dtbs-check

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
@@ -263,6 +263,7 @@
 
 &qusb2phy0 {
 	vdd-supply = <&vreg_l1b_0p925>;
+	vdda-pll-supply = <&vreg_l10a_1p8>;
 	vdda-phy-dpdm-supply = <&vreg_l7b_3p125>;
 
 	status = "okay";


### PR DESCRIPTION
`warnings_count--`

Fixes the
```
sdm660-xiaomi-jasmine.dtb: phy@c012000 (qcom,sdm660-qusb2-phy): 'vdda-pll-supply' is a required property
```

Still boots fine