### PR TITLE
Fix several dtbs_check errors related to panel supplies

### DIFF
--- a/Documentation/devicetree/bindings/display/panel/tianma,td4310.yaml
+++ b/Documentation/devicetree/bindings/display/panel/tianma,td4310.yaml
@@ -26,6 +26,15 @@ properties:
   backlight:
     description: phandle of the backlight device attached to the panel
 
+  vddio-supply:
+    description: phandle of the regulator that provides the supply for IO lines
+
+  vsp-supply:
+    description: phandle of the positive boost supply regulator
+
+  vsn-supply:
+    description: phandle of the negative boost supply regulator
+
   port: true
   rotation: true
   width-mm: true
@@ -35,6 +44,7 @@ required:
   - compatible
   - reg
   - reset-gpios
+  - vddio-supply
 
 unevaluatedProperties: false
 
@@ -48,6 +58,7 @@ examples:
             compatible = "tianma,td4310-xiaomi-whyred";
             reg = <0>;
             reset-gpios = <&tlmm 53 GPIO_ACTIVE_LOW>;
+            vddio-supply = <&vreg_l11a_1p8>;
             backlight = <&pm660l_wled>;
             port {
                 panel_in: endpoint {

--- a/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
@@ -161,6 +161,23 @@
 		regulator-boot-on;
 	};
 
+	/*
+	 * This is here until we have a driver for QPNP LCDB regulator.
+	 * It can emulate both positive LDO and negative NCP supplies for panel.
+	 */
+	lcdb_fixed: lcdb-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "lcdb";
+		/*
+		 * Actual range for LCDB is 4.0 - 6.0V, but
+		 * stock bootloader sets voltage to 5.4 V
+		 */
+		regulator-min-microvolt = <5400000>;
+		regulator-max-microvolt = <5400000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
 	battery: battery {
 			compatible = "simple-battery";
 
@@ -253,12 +270,16 @@
 		compatible = "txd,txdi600yanpa-43v3", "novatek,nt36672a";
 
 		vddio-supply = <&vreg_l11a_1p8>;
+		vddneg-supply = <&lcdb_fixed>;
+		vddpos-supply = <&lcdb_fixed>;
+
 		backlight = <&pm660l_wled>;
 
 		reset-gpios = <&tlmm 53 GPIO_ACTIVE_LOW>;
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&mdss_dsi_active &mdss_te_active>;
+
 		port {
 			panel_in: endpoint {
 				remote-endpoint = <&mdss_dsi0_out>;

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -106,6 +106,23 @@
 		regulator-always-on;
 		regulator-boot-on;
 	};
+
+	/*
+	 * This is here until we have a driver for QPNP LCDB regulator.
+	 * It can emulate both positive LDO and negative NCP supplies for panel.
+	 */
+	lcdb_fixed: lcdb-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "lcdb";
+		/*
+		 * Actual range for LCDB is 4.0 - 6.0V, but
+		 * stock bootloader sets voltage to 5.4 V
+		 */
+		regulator-min-microvolt = <5400000>;
+		regulator-max-microvolt = <5400000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
 };
 
 &adreno_gpu {
@@ -180,7 +197,11 @@
 		reg = <0>;
 
 		reset-gpios = <&tlmm 53 GPIO_ACTIVE_LOW>;
+
 		vddio-supply = <&vreg_l11a_1p8>;
+		vddneg-supply = <&lcdb_fixed>;
+		vddpos-supply = <&lcdb_fixed>;
+
 		backlight = <&pm660l_wled>;
 
 		pinctrl-names = "default";

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
@@ -74,6 +74,23 @@
 		regulator-boot-on;
 	};
 
+	/*
+	 * This is here until we have a driver for QPNP LCDB regulator.
+	 * It can emulate both positive LDO and negative NCP supplies for panel.
+	 */
+	lcdb_fixed: lcdb-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "lcdb";
+		/*
+		 * Actual range for LCDB is 4.0 - 6.0V, but
+		 * stock bootloader sets voltage to 5.4 V
+		 */
+		regulator-min-microvolt = <5400000>;
+		regulator-max-microvolt = <5400000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
 	gpio-keys {
 		compatible = "gpio-keys";
 
@@ -181,7 +198,11 @@
 		reg = <0>;
 
 		reset-gpios = <&tlmm 53 GPIO_ACTIVE_LOW>;
+
 		vddio-supply = <&vreg_l11a_1p8>;
+		vddneg-supply = <&lcdb_fixed>;
+		vddpos-supply = <&lcdb_fixed>;
+
 		backlight = <&pm660l_wled>;
 
 		pinctrl-names = "default";

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
@@ -78,6 +78,23 @@
 		regulator-boot-on;
 	};
 
+	/*
+	 * This is here until we have a driver for QPNP LCDB regulator.
+	 * It can emulate both positive LDO and negative NCP supplies for panel.
+	 */
+	lcdb_fixed: lcdb-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "lcdb";
+		/*
+		 * Actual range for LCDB is 4.0 - 6.0V, but
+		 * stock bootloader sets voltage to 5.4 V
+		 */
+		regulator-min-microvolt = <5400000>;
+		regulator-max-microvolt = <5400000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
 	gpio-keys {
 		compatible = "gpio-keys";
 

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-shenchao.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-shenchao.dts
@@ -38,6 +38,8 @@
 &panel {
 	compatible = "shenchao,fhdplus-video", "novatek,nt36672a";
 	vddio-supply = <&vreg_l11a_1p8>;
+	vddneg-supply = <&lcdb_fixed>;
+	vddpos-supply = <&lcdb_fixed>;
 };
 
 &tlmm {

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-tianma.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-tianma.dts
@@ -38,6 +38,8 @@
 &panel {
 	compatible = "tianma,tl063fvmca01-00", "novatek,nt36672a";
 	vddio-supply = <&vreg_l11a_1p8>;
+	vddneg-supply = <&lcdb_fixed>;
+	vddpos-supply = <&lcdb_fixed>;
 };
 
 &tlmm {


### PR DESCRIPTION
* Fix whyred's panel binding doc (Unevaluated properties are not allowed ('vddio-supply' was unexpected))
* Fix nt26672a panels missing supplies by providing fake lcdb node ('vddpos-supply' is a required property, 'vddneg-supply' is a required property)

Partial, temporaty fix for #125 