### PR TITLE
xiaomi-clover-plus: add irq-gpio to goodix-ts node

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-plus.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-plus.dts
@@ -46,6 +46,7 @@
 		pinctrl-3 = <&ts_int_input>;
 
 		reset-gpios = <&tlmm 66 GPIO_ACTIVE_HIGH>;
+		irq-gpios = <&tlmm 67 IRQ_TYPE_LEVEL_LOW>;
 
 		touchscreen-size-x = <1200>;
 		touchscreen-size-y = <1920>;


### PR DESCRIPTION
Add irq-gpio property to goodix-ts node to match downstream (https://github.com/pix106/android_kernel_xiaomi_southwest-4.19/blob/main/arch/arm64/boot/dts/vendor/qcom/xiaomi/mi/clover/clover-overlay.dtsi#L729). This also makes driver load goodix_9110_cfg.bin which content is extracted from downstream device tree (https://github.com/pix106/android_kernel_xiaomi_southwest-4.19/blob/main/arch/arm64/boot/dts/vendor/qcom/xiaomi/mi/clover/clover-overlay.dtsi#L749). It may be needed to include this .bin file into initramfs to get it loaded by driver.