### PR TITLE
CI: ignore dtbs_check errors with audio stuff

### DIFF
--- a/.github/workflows/analyze_dtbs_check.py
+++ b/.github/workflows/analyze_dtbs_check.py
@@ -6,6 +6,7 @@ import sys
 IGNORE_ERRORS = [
     '\'fb-panel\' does not match any of the regexes',
     '\'framebuffer-panel\' does not match any of the regexes',
+    'audio-codec@152c0000',
 ]
 
 def is_error_ignored(line: str) -> bool:


### PR DESCRIPTION
Since merging of audio stuff there was a regression in dtbs_check; logs are filled with this, for multiple devices:

```
 sdm630-nokia-pl2.dtb: audio-codec@152c0000 (qcom,msm8916-wcd-digital-codec): clock-names:0: 'ahbix-clk' was expected
 sdm630-nokia-pl2.dtb: audio-codec@152c0000 (qcom,msm8916-wcd-digital-codec): clock-names: ['mclk'] is too short
 sdm630-nokia-pl2.dtb: audio-codec@152c0000 (qcom,msm8916-wcd-digital-codec): clocks: [[132, 51, 1]] is too short
```

Even though e.g. nokia-pl2 was not touched in that series.

Until fixed, ignore it (but still needs to be fixed!)