### PR TITLE
Some more fixes for dtbs_check warnings

### DIFF
--- a/.github/workflows/analyze_dtbs_check.py
+++ b/.github/workflows/analyze_dtbs_check.py
@@ -4,8 +4,6 @@ import sys
 
 
 IGNORE_ERRORS = [
-    '\'fb-panel\' does not match any of the regexes',
-    '\'framebuffer-panel\' does not match any of the regexes',
 ]
 
 def is_error_ignored(line: str) -> bool:

--- a/.github/workflows/analyze_dtbs_check.py
+++ b/.github/workflows/analyze_dtbs_check.py
@@ -45,6 +45,9 @@ def main() -> int:
                     continue
                 if line.startswith('SCHEMA ') or line.startswith('DTC [C]'):
                     continue
+                # skip "make[x]: Leaving directory ..." / "make[x]: Entering directory ..."
+                if ('make' in line) and (' directory ' in line):
+                    continue
                 errors_count = errors_count + 1
                 if is_error_ignored(line):
                     errors_ignored = errors_ignored + 1

--- a/arch/arm64/boot/dts/qcom/sda660-xiaomi-clover.dts
+++ b/arch/arm64/boot/dts/qcom/sda660-xiaomi-clover.dts
@@ -83,41 +83,6 @@
 	status = "okay";
 };
 
-&simplefb {
-	/*
-	 * Prevent unused clocks and power domains from being disabled. It's
-	 * needed to keep bootloader-enabled display stack (and therefore
-	 * framebuffer) working.
-	 */
-	assigned-clocks = <&mmcc MDSS_MDP_CLK>,   /* from mdp */
-			  <&mmcc MDSS_VSYNC_CLK>;
-	assigned-clock-rates = <300000000>,
-				<19200000>;
-	clocks = <&mmcc MDSS_AHB_CLK>, /* from mdss & mdp */
-		<&mmcc MDSS_AXI_CLK>,
-		<&mmcc MDSS_VSYNC_CLK>,
-		<&mmcc MDSS_MDP_CLK>,
-		<&mmcc BYTE0_CLK_SRC>, /* from mdss_dsi0 */
-		<&mmcc PCLK0_CLK_SRC>,
-		<&mmcc MDSS_BYTE0_CLK>,
-		<&mmcc MDSS_BYTE0_INTF_CLK>,
-		<&mmcc MNOC_AHB_CLK>,
-		<&mmcc MISC_AHB_CLK>,
-		<&mmcc MDSS_PCLK0_CLK>,
-		<&mmcc MDSS_ESC0_CLK>;
-
-	power-domains = <&rpmpd SDM660_VDDCX>, <&mmcc MDSS_GDSC>;
-
-	/* Let simledrm framebuffer to know panel physical size to
-	   allow userspace to do proper DPI scaling */
-	panel = <&fb_panel>;
-
-	fb_panel: fb-panel {
-		width-mm = <107>;
-		height-mm = <172>;
-	};
-};
-
 &tlmm {
 	ts_int_active: ts-int-active-state {
 		pins = "gpio67";

--- a/arch/arm64/boot/dts/qcom/sdm630-sony-xperia-nile-pioneer.dts
+++ b/arch/arm64/boot/dts/qcom/sdm630-sony-xperia-nile-pioneer.dts
@@ -91,8 +91,13 @@
 /* Identifies itself as Synaptics TD4322Test */
 &touchscreen {
 	/*
-	 * Due to how fw_devlink works, abuse follower API to make touch probe
-	 * after panel, so that panel resets the gpio first, otherwise it fails
+	 * Because synaptics driver doesn't support reset-gpio,
+	 * we need to delay initialization of rmi_i2c driver
+	 * long enough until display subsystem probes and flips
+	 * gpio53.
 	 */
-	panel = <&panel>;
+	syna,startup-delay-ms = <500>;
+
+	/* This might be common for all nile devices, not only pioneer */
+	vio-supply = <&vreg_l11a_1p8>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -2010,7 +2010,7 @@
 			clocks = <&gcc GCC_BLSP2_QUP3_SPI_APPS_CLK>,
 				 <&gcc GCC_BLSP2_AHB_CLK>;
 			clock-names = "core", "iface";
-			clock-frequency = <400000>;
+
 			dmas = <&blsp2_dma 8>, <&blsp2_dma 9>;
 			dma-names = "tx", "rx";
 

--- a/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
@@ -42,15 +42,6 @@
 			height = <2160>;
 			stride = <(1080 * 4)>;
 			format = "a8r8g8b8";
-
-			/* In order to allow simpledrm framebuffer to know
-			 * physical dimensions */
-			panel = <&fb_panel>;
-
-			fb_panel: fb-panel {
-				width-mm = <68>;
-				height-mm = <136>;
-			};
 		};
 	};
 

--- a/arch/arm64/boot/dts/qcom/sdm636-motorola-beckham.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-motorola-beckham.dts
@@ -65,17 +65,6 @@
 				<&mmcc MDSS_ESC0_CLK>;
 			/* Prevent unused power domains from being disabled (similar to clocks) */
 			power-domains = <&rpmpd SDM660_VDDCX>, <&mmcc MDSS_GDSC>;
-
-			/* In order to allow simpledrm framebuffer to know
-			 * physical dimensions */
-			panel = <&fb_panel>;
-
-			status = "okay";
-
-			fb_panel: fb-panel {
-				width-mm = <68>;
-				height-mm = <121>;
-			};
 		};
 	};
 

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-whyred.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-whyred.dts
@@ -72,13 +72,6 @@
 				<&mmcc MDSS_ESC0_CLK>;
 
 			power-domains = <&rpmpd SDM660_VDDCX>, <&mmcc MDSS_GDSC>;
-
-			panel = <&fb_panel>;
-
-			fb_panel: framebuffer-panel {
-				width-mm = <68>;
-				height-mm = <136>;
-			};
 		};
 	};
 
@@ -183,12 +176,16 @@
 		pinctrl-1 = <&synats_int_sleep &synats_reset_sleep>;
 		pinctrl-names = "default", "sleep";
 
-		vdd-supply = <&vreg_l11a_1p8>;
+		vio-supply = <&vreg_l11a_1p8>;
 
 		syna,reset-delay-ms = <220>;
-		syna,startup-delay-ms = <220>;
-
-		panel = <&panel>;
+		/*
+		 * Because synaptics driver doesn't support reset-gpio,
+		 * we need to delay initialization of rmi_i2c driver
+		 * long enough until display subsystem probes and flips
+		 * gpio53.
+		 */
+		syna,startup-delay-ms = <500>;
 
 		rmi4-f01@1 {
 			reg = <0x01>;
@@ -198,16 +195,6 @@
 		rmi4-f11@11 {
 			reg = <0x11>;
 			syna,sensor-type = <1>;
-		};
-
-		rmi4-f12@12 {
-			reg = <0x12>;
-			syna,sensor-type = <1>;
-			syna,rezero-wait-ms = <200>;
-			syna,clip-x-low = <0>;
-			syna,clip-x-high = <1080>;
-			syna,clip-y-low = <0>;
-			syna,clip-y-high = <2160>;
 		};
 	};
 };

--- a/arch/arm64/boot/dts/qcom/sdm660-bbry-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-bbry-common.dtsi
@@ -65,15 +65,6 @@
 				<&mmcc MDSS_ESC0_CLK>;
 
 			power-domains = <&rpmpd SDM660_VDDCX>, <&mmcc MDSS_GDSC>;
-
-			/* In order to allow simpledrm framebuffer to know
-			 * physical dimensions */
-			panel = <&fb_panel>;
-
-			fb_panel: fb-panel {
-				width-mm = <63>;
-				height-mm = <95>;
-			};
 		};
 	};
 

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -33,13 +33,37 @@
 
 		stdout-path = "serial0:115200n8";
 
-		simplefb: framebuffer@9d400000 {
+		framebuffer@9d400000 {
 			compatible = "simple-framebuffer";
 			reg = <0x0 0x9d400000 0x0 (1200 * 1920 * 4)>;
 			width = <1200>;
 			height = <1920>;
 			stride = <(1200 * 4)>;
 			format = "a8r8g8b8";
+
+			/*
+			* Prevent unused clocks and power domains from being disabled. It's
+			* needed to keep bootloader-enabled display stack (and therefore
+			* framebuffer) working.
+			*/
+			assigned-clocks = <&mmcc MDSS_MDP_CLK>,   /* from mdp */
+					<&mmcc MDSS_VSYNC_CLK>;
+			assigned-clock-rates = <300000000>,
+						<19200000>;
+			clocks = <&mmcc MDSS_AHB_CLK>, /* from mdss & mdp */
+				<&mmcc MDSS_AXI_CLK>,
+				<&mmcc MDSS_VSYNC_CLK>,
+				<&mmcc MDSS_MDP_CLK>,
+				<&mmcc BYTE0_CLK_SRC>, /* from mdss_dsi0 */
+				<&mmcc PCLK0_CLK_SRC>,
+				<&mmcc MDSS_BYTE0_CLK>,
+				<&mmcc MDSS_BYTE0_INTF_CLK>,
+				<&mmcc MNOC_AHB_CLK>,
+				<&mmcc MISC_AHB_CLK>,
+				<&mmcc MDSS_PCLK0_CLK>,
+				<&mmcc MDSS_ESC0_CLK>;
+
+			power-domains = <&rpmpd SDM660_VDDCX>, <&mmcc MDSS_GDSC>;
 		};
 	};
 

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-plus.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-plus.dts
@@ -144,41 +144,6 @@
 	status = "okay";
 };
 
-&simplefb {
-	/*
-	 * Prevent unused clocks and power domains from being disabled. It's
-	 * needed to keep bootloader-enabled display stack (and therefore
-	 * framebuffer) working.
-	 */
-	assigned-clocks = <&mmcc MDSS_MDP_CLK>,   /* from mdp */
-			  <&mmcc MDSS_VSYNC_CLK>;
-	assigned-clock-rates = <300000000>,
-				<19200000>;
-	clocks = <&mmcc MDSS_AHB_CLK>, /* from mdss & mdp */
-		<&mmcc MDSS_AXI_CLK>,
-		<&mmcc MDSS_VSYNC_CLK>,
-		<&mmcc MDSS_MDP_CLK>,
-		<&mmcc BYTE0_CLK_SRC>, /* from mdss_dsi0 */
-		<&mmcc PCLK0_CLK_SRC>,
-		<&mmcc MDSS_BYTE0_CLK>,
-		<&mmcc MDSS_BYTE0_INTF_CLK>,
-		<&mmcc MNOC_AHB_CLK>,
-		<&mmcc MISC_AHB_CLK>,
-		<&mmcc MDSS_PCLK0_CLK>,
-		<&mmcc MDSS_ESC0_CLK>;
-
-	power-domains = <&rpmpd SDM660_VDDCX>, <&mmcc MDSS_GDSC>;
-
-	/* Let simledrm framebuffer to know panel physical size to
-	   allow userspace to do proper DPI scaling */
-	panel = <&fb_panel>;
-
-	fb_panel: fb-panel {
-		width-mm = <135>;
-		height-mm = <216>;
-	};
-};
-
 &tlmm {
 	lcd_bl_en_default: lcd-bl-en-default-state {
 		pins = "gpio72";

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
@@ -36,23 +36,6 @@
 			height = <2160>;
 			stride = <(1080 * 4)>;
 			format = "a8r8g8b8";
-
-			/* HACK:
-			 * Fake panel node for simple-framebuffer to calculate DPI from. Only
-			 * needs width & height specified. This allows us to break device link
-			 * from simplefb to mdss (implicitly via panel->mdp->mdss) to fix drm
-			 * device probe ordering. Without this, simpledrm would probe second
-			 * after msm-drm, and confuse userspace with 2 GPUs in /dev/dri.
-			 * Alternative workaround is to boot with kernel parameter
-			 * `fw_devlink=permissive`, which is worse, because it can hide other
-			 * issues with device dependencies.
-			 */
-			panel = <&fb_panel>;
-
-			fb_panel: fb-panel {
-				width-mm = <68>;
-				height-mm = <136>;
-			};
 		};
 	};
 

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
@@ -42,23 +42,6 @@
 			height = <2340>;
 			stride = <(1080 * 4)>;
 			format = "a8r8g8b8";
-
-			/* HACK:
-			 * Fake panel node for simple-framebuffer to calculate DPI from. Only
-			 * needs width & height specified. This allows us to break device link
-			 * from simplefb to mdss (implicitly via panel->mdp->mdss) to fix drm
-			 * device probe ordering. Without this, simpledrm would probe second
-			 * after msm-drm, and confuse userspace with 2 GPUs in /dev/dri.
-			 * Alternative workaround is to boot with kernel parameter
-			 * `fw_devlink=permissive`, which is worse, because it can hide other
-			 * issues with device dependencies.
-			 */
-			panel = <&fb_panel>;
-
-			fb_panel: fb-panel {
-				width-mm = <67>;
-				height-mm = <145>;
-			};
 		};
 	};
 


### PR DESCRIPTION
Need to track them all down and kill them with fire :fire: 

First fix is for: `sdm636-xiaomi-whyred.dtb: touchscreen@20 (syna,rmi4-i2c): Unevaluated properties are not allowed ('panel' was unexpected)`. `panel` property is described in `input/touchscreen/touchscreen.yaml`, which is not referenced for the main node of rmi4-i2c in `input/syna,rmi4.yaml`, but it is referenced in subnode description for functions 11/12. Seems technically rmi4-i2c is not a touchscreen, but underlying function11/12 is.

`clock-frequency` is not described in `spi/qcom,spi-qup.yaml`.

What's next on the list are fb-panel HACKs that need to be removed completely, probably. Unless trick with post-init-providers helps