### PR TITLE
Move clocks properties for the digital codec from device dts'es to the SoC dtsi

### DIFF
--- a/.github/workflows/analyze_dtbs_check.py
+++ b/.github/workflows/analyze_dtbs_check.py
@@ -6,7 +6,6 @@ import sys
 IGNORE_ERRORS = [
     '\'fb-panel\' does not match any of the regexes',
     '\'framebuffer-panel\' does not match any of the regexes',
-    'audio-codec@152c0000',
 ]
 
 def is_error_ignored(line: str) -> bool:

--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -2418,9 +2418,12 @@
 			compatible = "qcom,msm8916-wcd-digital-codec";
 			reg = <0x152c0000 0x400>;
 
-			clocks = <&q6afecc LPASS_CLK_ID_INT_MCLK_0 LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
-			clock-names = "mclk";
+			clocks = <&int_cdc_bclk>,
+				<&q6afecc LPASS_CLK_ID_INT_MCLK_0 LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
+			clock-names = "ahbix-clk", "mclk";
 
+			assigned-clocks = <&q6afecc LPASS_CLK_ID_INT_MCLK_0 LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
+			assigned-clock-rates = <9600000>;
 			// Resolve naming conflicts with digital and analog PDM_RX*
 			sound-name-prefix = "Digital";
 			#sound-dai-cells = <1>;

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -198,11 +198,6 @@
 };
 
 &lpass_codec {
-	clocks = <&int_cdc_bclk>,
-		 <&q6afecc LPASS_CLK_ID_INT_MCLK_0 LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
-	clock-names = "ahbix-clk", "mclk";
-	assigned-clocks = <&q6afecc LPASS_CLK_ID_INT_MCLK_0 LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
-	assigned-clock-rates = <9600000>;
 	status = "okay";
 };
 &pm660l_codec {

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
@@ -229,13 +229,6 @@
 };
 
 &lpass_codec {
-	clocks = <&int_cdc_bclk>,
-		 <&q6afecc LPASS_CLK_ID_INT_MCLK_0 LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
-	clock-names = "ahbix-clk", "mclk";
-
-	assigned-clocks = <&q6afecc LPASS_CLK_ID_INT_MCLK_0 LPASS_CLK_ATTRIBUTE_COUPLE_NO>;
-	assigned-clock-rates = <9600000>;
-
 	status = "okay";
 };
 


### PR DESCRIPTION
This PR moves clocks properties for the digital LPASS codec from device dts'es to the SoC dtsi.
This resolves dtbs_check errors related to the audio.