### PR TITLE
[6.17] Display/GPU fixes

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630.dtsi
@@ -1621,6 +1621,7 @@
 			reg-names = "mdss_phys", "vbif_phys";
 
 			power-domains = <&mmcc MDSS_GDSC>;
+			resets = <&mmcc MDSS_BCR>;
 
 			clocks = <&mmcc MDSS_AHB_CLK>,
 				 <&mmcc MDSS_AXI_CLK>,

--- a/arch/arm64/boot/dts/qcom/sdm660.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660.dtsi
@@ -74,20 +74,20 @@
 		}; */
 
 		/* bins 157,146 -> bits 6,5 */
-		opp-700000000 {
+		/*opp-700000000 {
 			opp-hz = /bits/ 64 <700000000>;
 			opp-level = <RPM_SMD_LEVEL_TURBO>;
 			opp-peak-kBps = <5184000>;
 			opp-supported-hw = <0x60>;
-		};
+		};*/
 
 		/* bins 157,146,135 -> bits 6,5,4 */
-		opp-647000000 {
+		/*opp-647000000 {
 			opp-hz = /bits/ 64 <647000000>;
 			opp-level = <RPM_SMD_LEVEL_NOM_PLUS>;
 			opp-peak-kBps = <4068000>;
 			opp-supported-hw = <0x70>;
-		};
+		};*/
 
 		/* bins 157,146,135 -> bits 6,5,4 */
 		opp-588000000 {

--- a/drivers/clk/qcom/mmcc-sdm660.c
+++ b/drivers/clk/qcom/mmcc-sdm660.c
@@ -2781,6 +2781,7 @@ static struct gdsc *mmcc_sdm660_gdscs[] = {
 };
 
 static const struct qcom_reset_map mmcc_660_resets[] = {
+	[MDSS_BCR] = { 0x2300 },
 	[CAMSS_MICRO_BCR] = { 0x3490 },
 };
 

--- a/drivers/gpu/drm/msm/adreno/adreno_gpu.c
+++ b/drivers/gpu/drm/msm/adreno/adreno_gpu.c
@@ -340,18 +340,18 @@ int adreno_fault_handler(struct msm_gpu *gpu, unsigned long iova, int flags,
 			scratch[0], scratch[1], scratch[2], scratch[3]);
 
 	if (do_devcoredump) {
-		struct msm_gpu_fault_info fault_info = {};
+		/* struct msm_gpu_fault_info fault_info = {}; */
 
 		/* Turn off the hangcheck timer to keep it from bothering us */
 		timer_delete(&gpu->hangcheck_timer);
 
-		fault_info.ttbr0 = info->ttbr0;
+		/* fault_info.ttbr0 = info->ttbr0;
 		fault_info.iova  = iova;
 		fault_info.flags = flags;
 		fault_info.type  = type;
 		fault_info.block = block;
 
-		msm_gpu_fault_crashstate_capture(gpu, &fault_info);
+		msm_gpu_fault_crashstate_capture(gpu, &fault_info); */
 	}
 
 	return 0;

--- a/include/dt-bindings/clock/qcom,mmcc-sdm660.h
+++ b/include/dt-bindings/clock/qcom,mmcc-sdm660.h
@@ -157,6 +157,7 @@
 #define BIMC_SMMU_GDSC							7
 
 #define CAMSS_MICRO_BCR				 0
+#define MDSS_BCR				1
 
 #endif
 


### PR DESCRIPTION
Grab description from one of:
* https://patchwork.kernel.org/project/linux-arm-msm/list/?series=1004174&state=%2A&archive=both
* https://patchwork.kernel.org/project/linux-arm-msm/list/?series=1004250&state=%2A&archive=both
* https://patchwork.kernel.org/project/linux-arm-msm/list/?series=1002506&state=%2A&archive=both

Important bit is
> This also fixes display init on Linux v6.17.

For the reference, without `MDSS_BCR` during boot display doesn't come up (black) until you turn it off/on, or you'll see plain blue display instead of kernel logs or splash screen and this will be in dmesg:
```
[  115.477507] hw recovery is not complete for ctl:2
[  115.479056] [drm:dpu_encoder_phys_vid_prepare_for_kickoff:569] [dpu error]enc33 intf1 ctl 2 reset failure: -22
[  116.181469] [drm:dpu_encoder_frame_done_timeout:2727] [dpu error]enc33 frame done timeout
[  116.345396] [drm:dpu_encoder_frame_done_timeout:2727] [dpu error]enc33 frame done timeout
[  116.748773] [drm:dpu_encoder_frame_done_timeout:2727] [dpu error]enc33 frame done timeout
[  117.213569] [drm:dpu_encoder_frame_done_timeout:2727] [dpu error]enc33 frame done timeout
[  117.645205] hw recovery is not complete for ctl:2
[  117.647726] [drm:dpu_encoder_phys_vid_prepare_for_kickoff:569] [dpu error]enc33 intf1 ctl 2 reset failure: -22
[  117.650885] [drm:dpu_encoder_frame_done_timeout:2727] [dpu error]enc33 frame done timeout
[  118.284506] [drm:dpu_encoder_frame_done_timeout:2727] [dpu error]enc33 frame done timeout
...
[  129.115542] [drm:dpu_encoder_frame_done_timeout:2727] [dpu error]enc33 frame done timeout
[  141.547007] dpu_encoder_frame_done_timeout: 2 callbacks suppressed
```
---
Also partially undo https://patchwork.freedesktop.org/series/114004/

Suspicion is that msm_gpu_fault_crashstate_capture() does something
that causes hang for the whole device, so you cannot get any crash
dumps. Faults still happen sometimes, and they are logged, but
device remains usable.

This requires running with `FD_MESA_DEBUG=noblit,inorder,gmem` otherwise your device is unusable brick of plastic.