### PR TITLE
clover and clover-plus brightness rework

### DIFF
--- a/.github/workflows/check-dtschema.yml
+++ b/.github/workflows/check-dtschema.yml
@@ -8,7 +8,7 @@ on:
     tags:
       - v*-sdm660
 jobs:
-  dbts-check:
+  dtbs-check:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -21,6 +21,9 @@ jobs:
         with:
           files: |
             **.yaml
+      - name: Update package lists
+        run: |
+          sudo apt update
       - name: Install dependencies
         run: |
           sudo apt install -yqq bison build-essential device-tree-compiler flex gcc-aarch64-linux-gnu python3 python3-dev python3-venv swig

--- a/arch/arm64/boot/dts/qcom/sda660-xiaomi-clover.dts
+++ b/arch/arm64/boot/dts/qcom/sda660-xiaomi-clover.dts
@@ -73,6 +73,7 @@
 	qcom,switching-freq = <800>;
 	qcom,current-limit-microamp = <20000>;
 	qcom,num-strings = <3>;
+	qcom,cabc;
 
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-plus.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-plus.dts
@@ -62,28 +62,24 @@
 		enable-supply = <&vreg_bl_vddio>;
 
 		bl-name = "lcd-backlight";
-		dev-ctrl = /bits/ 8 <0x05>;
+		dev-ctrl = /bits/ 8 <0x87>; /* pwm + i2c combined mode after shaper block, 12-bit */
 		init-brt = /bits/ 8 <0x7f>; /* 50% brightness */
 
-		/* TODO: Stange thing, according to datasheet for LP8556 valid
-		 * EEPROM addresses range from 0x98h to 0xAF, but driver
-		 * thinks A0 is lowest valid address. So write to 9E will be
-		 * silently discarded. Bug in driver? */
 		rom-9eh {
-			rom-addr = /bits/ 8 <0x9E>;
+			rom-addr = /bits/ 8 <0x9e>;
 			rom-val = /bits/ 8 <0x20>;
 		};
 		rom-a0h {
 			rom-addr = /bits/ 8 <0xa0>;
-			rom-val = /bits/ 8 <0x09>;
+			rom-val = /bits/ 8 <0x09>; /* max current 23.5mA */
 		};
 		rom-a1h {
 			rom-addr = /bits/ 8 <0xa1>;
-			rom-val = /bits/ 8 <0x5f>;
+			rom-val = /bits/ 8 <0x5f>; /* max current 23.5mA */
 		};
 		rom-a3h {
 			rom-addr = /bits/ 8 <0xa3>;
-			rom-val = /bits/ 8 <0x0e>;
+			rom-val = /bits/ 8 <0x0e>; /* Select brightness change transition duration 000 = 0 ms (immediate change)*/
 		};
 		rom-a5h {
 			rom-addr = /bits/ 8 <0xa5>;

--- a/drivers/gpu/drm/panel/panel-novatek-nt51021.c
+++ b/drivers/gpu/drm/panel/panel-novatek-nt51021.c
@@ -41,6 +41,36 @@ static void nt51021_boe_reset(struct boe_nt51021_desc *ctx)
 	usleep_range(10000, 11000);
 }
 
+static void nt51021_cabc_on(struct mipi_dsi_multi_context *dsi_ctx)
+{
+	if (dsi_ctx->accum_err)
+		return;
+
+	mipi_dsi_generic_write_seq_multi(dsi_ctx, 0x8f, 0x00);
+	mipi_dsi_usleep_range(dsi_ctx, 1000, 2000);
+	mipi_dsi_generic_write_seq_multi(dsi_ctx, 0x8f, 0xa5);
+	mipi_dsi_usleep_range(dsi_ctx, 1000, 2000);
+	mipi_dsi_generic_write_seq_multi(dsi_ctx, 0x83, 0xbb);
+	mipi_dsi_generic_write_seq_multi(dsi_ctx, 0x84, 0x22);
+	mipi_dsi_generic_write_seq_multi(dsi_ctx, 0x90, 0x40);
+	mipi_dsi_generic_write_seq_multi(dsi_ctx, 0x8f, 0x00);
+	mipi_dsi_usleep_range(dsi_ctx, 1000, 2000);
+}
+
+static void nt51021_cabc_off(struct mipi_dsi_multi_context *dsi_ctx)
+{
+	if (dsi_ctx->accum_err)
+		return;
+
+	mipi_dsi_generic_write_seq_multi(dsi_ctx, 0x8f, 0xa5);
+	mipi_dsi_usleep_range(dsi_ctx, 1000, 2000);
+	mipi_dsi_generic_write_seq_multi(dsi_ctx, 0x83, 0xbb);
+	mipi_dsi_generic_write_seq_multi(dsi_ctx, 0x84, 0x22);
+	mipi_dsi_generic_write_seq_multi(dsi_ctx, 0x90, 0xc0);
+	mipi_dsi_generic_write_seq_multi(dsi_ctx, 0x8f, 0x00);
+	mipi_dsi_usleep_range(dsi_ctx, 1000, 2000);
+}
+
 static int nt51021_boe_8_init(struct boe_nt51021_desc *ctx)
 {
 	struct mipi_dsi_multi_context dsi_ctx = { .dsi = ctx->dsi };
@@ -298,6 +328,8 @@ static int nt51021_boe_8_init(struct boe_nt51021_desc *ctx)
 	mipi_dsi_usleep_range(&dsi_ctx, 5000, 6000);
 	mipi_dsi_generic_write_seq_multi(&dsi_ctx, 0x8f, 0x00);
 	mipi_dsi_usleep_range(&dsi_ctx, 1000, 2000);
+
+	nt51021_cabc_on(&dsi_ctx);
 
 	return dsi_ctx.accum_err;
 }
@@ -557,12 +589,17 @@ static int nt51021_boe_10wu_init(struct boe_nt51021_desc *ctx)
 	mipi_dsi_generic_write_seq_multi(&dsi_ctx, 0x8f, 0x00);
 	mipi_dsi_usleep_range(&dsi_ctx, 1000, 2000);
 
+	nt51021_cabc_on(&dsi_ctx);
+	mipi_dsi_usleep_range(&dsi_ctx, 1000, 2000);
+
 	return dsi_ctx.accum_err;
 }
 
 static int nt51021_boe_off(struct boe_nt51021_desc *ctx)
 {
 	struct mipi_dsi_multi_context dsi_ctx = { .dsi = ctx->dsi };
+
+	nt51021_cabc_off(&dsi_ctx);
 
 	mipi_dsi_generic_write_seq_multi(&dsi_ctx, 0x8f, 0xa5);
 	mipi_dsi_msleep(&dsi_ctx, 20);


### PR DESCRIPTION
Both panels for xiaomi-clover and xiaomi-clover-plus support content-adaptive brightness control, so add needed programming sequences to enable this feature and configure backlight IC's for both devices to support this.