### PR TITLE
There's no SD card slot on jasmine

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
@@ -563,13 +563,6 @@
 	status = "okay";
 };
 
-&sdhc_2 {
-	vmmc-supply = <&vreg_l5b_2p95>;
-	vqmmc-supply = <&vreg_l2b_2p95>;
-
-	status = "okay";
-};
-
 &tlmm {
 	gpio-reserved-ranges = <8 4>;
 


### PR DESCRIPTION
There is [no SD card slot](https://www.gsmarena.com/xiaomi_mi_a2_(mi_6x)-9140.php) on jasmine_sprout, so delete the node thus keeping default `status = "disabled"` inherited from base `sdm630.dtsi`