### PR TITLE
whyred/pioneer: delay touch probe even longer to fix race with display reset

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-sony-xperia-nile-pioneer.dts
+++ b/arch/arm64/boot/dts/qcom/sdm630-sony-xperia-nile-pioneer.dts
@@ -96,7 +96,7 @@
 	 * long enough until display subsystem probes and flips
 	 * gpio53.
 	 */
-	syna,startup-delay-ms = <500>;
+	syna,startup-delay-ms = <600>;
 
 	/* This might be common for all nile devices, not only pioneer */
 	vio-supply = <&vreg_l11a_1p8>;

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-whyred.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-whyred.dts
@@ -185,7 +185,7 @@
 		 * long enough until display subsystem probes and flips
 		 * gpio53.
 		 */
-		syna,startup-delay-ms = <500>;
+		syna,startup-delay-ms = <600>;
 
 		rmi4-f01@1 {
 			reg = <0x01>;


### PR DESCRIPTION
damn syna Register Mapped Interface touchscreen still doesn't probe reliably enough.