### PR TITLE
Clover battery fixup

### DIFF
--- a/arch/arm64/boot/dts/qcom/sda660-xiaomi-clover.dts
+++ b/arch/arm64/boot/dts/qcom/sda660-xiaomi-clover.dts
@@ -9,6 +9,16 @@
 / {
 	model = "Xiaomi Mi Pad 4";
 	compatible = "xiaomi,clover", "qcom,sda660";
+
+	battery: battery {
+		compatible = "simple-battery";
+
+		device-chemistry = "lithium-ion";
+
+		charge-full-design-microamp-hours = <6010000>;
+		voltage-min-design-microvolt = <3400000>;
+		voltage-max-design-microvolt = <4400000>;
+	};
 };
 
 &blsp_i2c3 {

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -67,14 +67,6 @@
 		};
 	};
 
-	battery: battery {
-		compatible = "simple-battery";
-
-		charge-full-design-microamp-hours = <4000000>;
-		voltage-min-design-microvolt = <3400000>;
-		voltage-max-design-microvolt = <4408000>;
-	};
-
 	lcd_pwr: lcd-power-regulator {
 		compatible = "regulator-fixed";
 		regulator-name = "lcd_pwr";

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-plus.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-plus.dts
@@ -10,6 +10,16 @@
 	model = "Xiaomi Mi Pad 4 Plus";
 	compatible = "xiaomi,clover-plus", "qcom,sdm660";
 
+	battery: battery {
+		compatible = "simple-battery";
+
+		device-chemistry = "lithium-ion";
+
+		charge-full-design-microamp-hours = <8620000>;
+		voltage-min-design-microvolt = <3400000>;
+		voltage-max-design-microvolt = <4400000>;
+	};
+
 	vreg_bl_vddio: lcd-backlight-regulator {
 		compatible = "regulator-fixed";
 


### PR DESCRIPTION
Regular clover and clover-plus have different battery capacities, so define the battery nodes in the corresponding dts'es with capacity values taken from downstream.
regular clover: https://github.com/xiaomi-sdm660/android_kernel_xiaomi_sdm660/blob/11-EAS/arch/arm/boot/dts/qcom/xiaomi/mi/clover/batterydata-zql5018-6000mah.dtsi
clover-plus: https://github.com/xiaomi-sdm660/android_kernel_xiaomi_sdm660/blob/11-EAS/arch/arm/boot/dts/qcom/xiaomi/mi/clover/batterydata-zql6019-8600mah.dtsi