### PR TITLE
input: touchscreen: Add NT36672A e7t variant support for Redmi Note 6 Pro

### DIFF
--- a/Documentation/devicetree/bindings/input/touchscreen/novatek,nvt-ts.yaml
+++ b/Documentation/devicetree/bindings/input/touchscreen/novatek,nvt-ts.yaml
@@ -17,6 +17,7 @@ properties:
     enum:
       - novatek,nt11205-ts
       - novatek,nt36672a-ts
+      - novatek,nt36672a-e7t-ts
 
   reg:
     maxItems: 1

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -137,7 +137,7 @@
 	status = "okay";
 
 	touchscreen@1 {
-		compatible = "novatek,nt36672a-ts";
+		compatible = "novatek,nt36672a-e7t-ts";
 		reg = <0x1>;
 		iovcc-supply = <&vreg_l11a_1p8>;
 		interrupts-extended = <&tlmm 67 IRQ_TYPE_EDGE_RISING>;

--- a/drivers/input/touchscreen/novatek-nvt-ts.c
+++ b/drivers/input/touchscreen/novatek-nvt-ts.c
@@ -410,9 +410,15 @@ static const struct nvt_ts_i2c_chip_data nvt_nt36672a_ts_data = {
 	.chip_id = 0x08,
 };
 
+static const struct nvt_ts_i2c_chip_data nvt_nt36672a_e7t_ts_data = {
+	.wake_type = 0x02,
+	.chip_id = 0x08,
+};
+
 static const struct of_device_id nvt_ts_of_match[] = {
 	{ .compatible = "novatek,nt11205-ts", .data = &nvt_nt11205_ts_data },
 	{ .compatible = "novatek,nt36672a-ts", .data = &nvt_nt36672a_ts_data },
+	{ .compatible = "novatek,nt36672a-e7t-ts", .data = &nvt_nt36672a_e7t_ts_data },
 	{ }
 };
 MODULE_DEVICE_TABLE(of, nvt_ts_of_match);
@@ -420,6 +426,7 @@ MODULE_DEVICE_TABLE(of, nvt_ts_of_match);
 static const struct i2c_device_id nvt_ts_i2c_id[] = {
 	{ "nt11205-ts", (unsigned long) &nvt_nt11205_ts_data },
 	{ "nt36672a-ts", (unsigned long) &nvt_nt36672a_ts_data },
+	{ "nt36672a-e7t-ts", (unsigned long) &nvt_nt36672a_e7t_ts_data },
 	{ }
 };
 MODULE_DEVICE_TABLE(i2c, nvt_ts_i2c_id);


### PR DESCRIPTION
## Summary
This PR adds support for the Novatek NT36672A e7t touchscreen variant found on the Xiaomi Redmi Note 6 Pro (tulip).
## Changes
- Add new chip data structure for NT36672A e7t variant with correct wake_type (0x02)
- Add device tree binding for `novatek,nt36672a-e7t-ts`
- Register variant in both OF and I2C device ID tables