### PR TITLE
arm64: dts: qcom: add sdm660-xiaomi-common.dtsi for Xiaomi SDM660-family devices

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -4,25 +4,12 @@
 /dts-v1/;
 
 #include "sdm636.dtsi"
-#include "pm660.dtsi"
-#include "pm660l.dtsi"
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/input/gpio-keys.h>
-#include <dt-bindings/leds/common.h>
-#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
-#include <dt-bindings/sound/qcom,q6afe.h>
-#include <dt-bindings/sound/qcom,q6asm.h>
+#include "sdm660-xiaomi-common.dtsi"
 
 / {
 	model = "Xiaomi Redmi Note 6 Pro";
 	compatible = "xiaomi,tulip", "qcom,sdm636";
 	chassis-type = "handset";
-
-	aliases {
-		serial0 = &blsp1_uart2; /* Debug UART */
-		serial1 = &blsp2_uart1; /* Bluetooth UART */
-	};
 
 	battery: battery {
 		compatible = "simple-battery";
@@ -37,8 +24,6 @@
 		#size-cells = <2>;
 		ranges;
 
-		stdout-path = "serial0:115200n8";
-
 		framebuffer0: framebuffer@9d400000 {
 			compatible = "simple-framebuffer";
 			reg = <0 0x9d400000 0x0 (1080 * 2280 * 4)>;
@@ -46,36 +31,6 @@
 			height = <2280>;
 			stride = <(1080 * 4)>;
 			format = "a8r8g8b8";
-		};
-	};
-
-	gpio-hall-sensor {
-		compatible = "gpio-keys";
-
-		pinctrl-0 = <&gpio_hall_sensor_default>;
-		pinctrl-names = "default";
-
-		switch {
-			label = "Hall Effect Sensor";
-			gpios = <&tlmm 75 GPIO_ACTIVE_LOW>;
-			linux,input-type = <EV_SW>;
-			linux,code = <SW_LID>;
-			linux,can-disable;
-			wakeup-source;
-		};
-	};
-
-	gpio-keys {
-		compatible = "gpio-keys";
-
-		pinctrl-0 = <&vol_up_default>;
-		pinctrl-names = "default";
-
-		key-volup {
-			label = "Volume Up";
-			gpios = <&pm660l_gpios 7 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_VOLUMEUP>;
-			debounce-interval = <15>;
 		};
 	};
 
@@ -99,16 +54,6 @@
 		};
 	};
 
-	vph_pwr: vph-pwr-regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "vph_pwr";
-		regulator-min-microvolt = <3700000>;
-		regulator-max-microvolt = <3700000>;
-
-		regulator-always-on;
-		regulator-boot-on;
-	};
-
 	/*
 	 * This is here until we have a driver for QPNP LCDB regulator.
 	 * It can emulate both positive LDO and negative NCP supplies for panel.
@@ -127,12 +72,8 @@
 	};
 };
 
-&adreno_gpu {
-	status = "okay";
-};
-
 &adreno_gpu_zap {
-	firmware-name = "a512_zap.mbn";
+	firmware-name = "qcom/sdm660/xiaomi/tulip/a512_zap.mdt";
 };
 
 &blsp_i2c1 {
@@ -164,28 +105,11 @@
 	status = "okay";
 };
 
-&blsp1_uart2 {
+&gpio_hall_sensor {
 	status = "okay";
-};
-
-&blsp2_uart1 {
-	status = "okay";
-
-	bluetooth {
-		compatible = "qcom,wcn3990-bt";
-		vddxo-supply = <&vreg_l9a_1p8>; // downstream: vdd-core-supply
-		vddrf-supply = <&vreg_l6a_1p3>; // vdd-pa-supply
-		vddch0-supply = <&vreg_l19a_3p3>; // vdd-ldo-supply
-		vddio-supply = <&vreg_l13a_1p8>; // chip-pwd-supply ? // TODO: check
-		max-speed = <3200000>;
-	};
 };
 
 &lpass_codec {
-	status = "okay";
-};
-
-&mdss {
 	status = "okay";
 };
 
@@ -232,10 +156,6 @@
 	status = "okay";
 };
 
-&mmss_smmu {
-	status = "okay";
-};
-
 &pm660_charger {
 	monitored-battery = <&battery>;
 
@@ -249,100 +169,15 @@
 	status = "okay";
 };
 
-&pm660_haptics {
-	status = "okay";
-};
-
-&pm660_rradc {
-	status = "okay";
-};
-
 &pm660l_codec {
-	vdd-cdc-io-supply = <&vreg_s4a_2p04>;
-	vdd-cdc-tx-rx-cx-supply = <&vreg_s4a_2p04>;
-	vdd-micbias-supply = <&vreg_l7b_3p125>;
-
-	qcom,micbias-lvl = <2600>;
-	qcom,micbias1-ext-cap;
-
 	status = "okay";
-};
-
-&pm660l_gpios {
-	vol_up_default: vol-up-default-state {
-		pins = "gpio7";
-		function = PMIC_GPIO_FUNC_NORMAL;
-		bias-pull-up;
-		input-enable;
-		qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
-	};
 };
 
 &pm660l_lpg {
-	#address-cells = <1>;
-	#size-cells = <0>;
-	qcom,power-source = <1>;
-
 	status = "okay";
-
-	led@3 {
-		reg = <3>;
-		color = <LED_COLOR_ID_WHITE>;
-		function = LED_FUNCTION_STATUS;
-	};
 };
 
 &pm660l_wled {
-	qcom,switching-freq = <800>;
-	qcom,current-limit-microamp = <20000>;
-	qcom,num-strings = <2>;
-
-	status = "okay";
-};
-
-&pon_pwrkey {
-	status = "okay";
-};
-
-&pon_resin {
-	linux,code = <KEY_VOLUMEDOWN>;
-
-	status = "okay";
-};
-
-&q6afedai {
-	dai@81 {
-		reg = <INT0_MI2S_RX>;
-		qcom,sd-lines = <0 1>;
-	};
-
-	dai@88 {
-		reg = <INT3_MI2S_TX>;
-		qcom,sd-lines = <0 1>;
-	};
-};
-
-&q6asmdai {
-	dai@0 {
-		reg = <0>;
-	};
-
-	dai@1 {
-		reg = <1>;
-	};
-};
-
-&qusb2phy0 {
-	vdd-supply = <&vreg_l1b_0p925>;
-	vdda-pll-supply = <&vreg_l10a_1p8>;
-	vdda-phy-dpdm-supply = <&vreg_l7b_3p125>;
-
-	status = "okay";
-};
-
-&remoteproc_mss {
-	firmware-name = "mba.mbn", "modem.mdt";
-
 	status = "okay";
 };
 
@@ -600,42 +435,7 @@
 	};
 };
 
-&sdc2_state_on {
-	sd-cd-pins {
-		pins = "gpio54";
-		function = "gpio";
-		bias-pull-up;
-		drive-strength = <2>;
-	};
-};
-
-&sdc2_state_off {
-	sd-cd-pins {
-		pins = "gpio54";
-		function = "gpio";
-		bias-disable;
-		drive-strength = <2>;
-	};
-};
-
-&sdhc_1 {
-	supports-cqe;
-
-	mmc-hs200-1_8v;
-	mmc-hs400-1_8v;
-	mmc-hs400-enhanced-strobe;
-
-	vmmc-supply = <&vreg_l4b_2p95>;
-	vqmmc-supply = <&vreg_l8a_1p8>;
-
-	status = "okay";
-};
-
 &sdhc_2 {
-	cd-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
-	vmmc-supply = <&vreg_l5b_2p95>;
-	vqmmc-supply = <&vreg_l2b_2p95>;
-
 	status = "okay";
 };
 
@@ -713,15 +513,6 @@
 };
 
 &tlmm {
-	gpio-reserved-ranges = <8 4>;
-
-	gpio_hall_sensor_default: gpio-hall-sensor-default-state {
-		pins = "gpio75";
-		function = "gpio";
-		drive-strength = <6>;
-		bias-pull-up;
-	};
-
 	mdss_dsi_active: mdss-dsi-active-state {
 		function = "gpio";
 		pins = "gpio53";
@@ -758,31 +549,3 @@
 	};
 };
 
-&usb3 {
-	qcom,select-utmi-as-pipe-clk;
-
-	status = "okay";
-};
-
-&usb3_dwc3 {
-	maximum-speed = "high-speed";
-	phys = <&qusb2phy0>;
-	phy-names = "usb2-phy";
-	dr_mode = "peripheral";
-};
-
-&venus {
-	firmware-name = "qcom/venus-4.4/venus.mdt";
-
-	status = "okay";
-};
-
-&wifi {
-	vdd-0.8-cx-mx-supply = <&vreg_l5a_0p848>;
-	vdd-1.8-xo-supply = <&vreg_l9a_1p8>;
-	vdd-1.3-rfa-supply = <&vreg_l6a_1p3>;
-	vdd-3.3-ch0-supply = <&vreg_l19a_3p3>;
-	vdd-3.3-ch1-supply = <&vreg_l19a_3p3>;
-
-	status = "okay";
-};

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-whyred.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-whyred.dts
@@ -5,13 +5,7 @@
 /dts-v1/;
 
 #include "sdm636.dtsi"
-#include "pm660.dtsi"
-#include "pm660l.dtsi"
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/input/gpio-keys.h>
-#include <dt-bindings/leds/common.h>
-#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
+#include "sdm660-xiaomi-common.dtsi"
 
 /delete-node/ &zap_shader_region;
 
@@ -19,11 +13,6 @@
 	model = "Xiaomi Redmi Note 5 Pro";
 	compatible = "xiaomi,whyred", "qcom,sdm636";
 	chassis-type = "handset";
-
-	aliases {
-		serial0 = &blsp1_uart2; /* Debug UART */
-		serial1 = &blsp2_uart1; /* Bluetooth UART */
-	};
 
 	battery: battery {
 		compatible = "simple-battery";
@@ -37,8 +26,6 @@
 		#address-cells = <2>;
 		#size-cells = <2>;
 		ranges;
-
-		stdout-path = "serial0:115200n8";
 
 		framebuffer0: framebuffer@9d400000 {
 			compatible = "simple-framebuffer";
@@ -75,36 +62,6 @@
 		};
 	};
 
-	gpio-hall-sensor {
-		compatible = "gpio-keys";
-
-		pinctrl-0 = <&gpio_hall_sensor_default>;
-		pinctrl-names = "default";
-
-		switch {
-			label = "Hall Effect Sensor";
-			gpios = <&tlmm 75 GPIO_ACTIVE_LOW>;
-			linux,input-type = <EV_SW>;
-			linux,code = <SW_LID>;
-			linux,can-disable;
-			wakeup-source;
-		};
-	};
-
-	gpio-keys {
-		compatible = "gpio-keys";
-
-		pinctrl-0 = <&vol_up_default>;
-		pinctrl-names = "default";
-
-		key-volup {
-			label = "Volume Up";
-			gpios = <&pm660l_gpios 7 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_VOLUMEUP>;
-			debounce-interval = <15>;
-		};
-	};
-
 	reserved-memory {
 		#address-cells = <2>;
 		#size-cells = <2>;
@@ -135,24 +92,10 @@
 			no-map;
 		};
 	};
-
-	vph_pwr: vph-pwr-regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "vph_pwr";
-		regulator-min-microvolt = <3700000>;
-		regulator-max-microvolt = <3700000>;
-
-		regulator-always-on;
-		regulator-boot-on;
-	};
-};
-
-&adreno_gpu {
-	status = "okay";
 };
 
 &adreno_gpu_zap {
-	firmware-name = "a512_zap.mbn";
+	firmware-name = "qcom/sdm660/xiaomi/whyred/a512_zap.mdt";
 	memory-region = <&zap_shader_region>;
 };
 
@@ -199,20 +142,7 @@
 	};
 };
 
-&blsp2_uart1 {
-	status = "okay";
-
-	bluetooth {
-		compatible = "qcom,wcn3990-bt";
-		vddxo-supply = <&vreg_l9a_1p8>;
-		vddrf-supply = <&vreg_l6a_1p3>;
-		vddch0-supply = <&vreg_l19a_3p3>;
-		vddio-supply = <&vreg_l13a_1p8>;
-		max-speed = <3200000>;
-	};
-};
-
-&mdss {
+&gpio_hall_sensor {
 	status = "okay";
 };
 
@@ -259,10 +189,6 @@
 	status = "okay";
 };
 
-&mmss_smmu {
-	status = "okay";
-};
-
 &pm660_charger {
 	monitored-battery = <&battery>;
 
@@ -276,67 +202,11 @@
 	status = "okay";
 };
 
-&pm660_haptics {
-	status = "okay";
-};
-
-&pm660_rradc {
-	status = "okay";
-};
-
-&pm660l_gpios {
-	vol_up_default: vol-up-default-state {
-		pins = "gpio7";
-		function = PMIC_GPIO_FUNC_NORMAL;
-		bias-pull-up;
-		input-enable;
-		qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
-	};
-};
-
 &pm660l_lpg {
-	#address-cells = <1>;
-	#size-cells = <0>;
-	qcom,power-source = <1>;
-
 	status = "okay";
-
-	led@3 {
-		reg = <3>;
-		color = <LED_COLOR_ID_WHITE>;
-		function = LED_FUNCTION_STATUS;
-	};
 };
 
 &pm660l_wled {
-	qcom,switching-freq = <800>;
-	qcom,current-limit-microamp = <20000>;
-	qcom,num-strings = <2>;
-
-	status = "okay";
-};
-
-&pon_pwrkey {
-	status = "okay";
-};
-
-&pon_resin {
-	linux,code = <KEY_VOLUMEDOWN>;
-
-	status = "okay";
-};
-
-&qusb2phy0 {
-	vdd-supply = <&vreg_l1b_0p925>;
-	vdda-pll-supply = <&vreg_l10a_1p8>;
-	vdda-phy-dpdm-supply = <&vreg_l7b_3p125>;
-
-	status = "okay";
-};
-
-&remoteproc_mss {
-	firmware-name = "mba.mbn", "modem.mdt";
-
 	status = "okay";
 };
 
@@ -595,48 +465,11 @@
 	};
 };
 
-&sdc2_state_on {
-	sd-cd-pins {
-		pins = "gpio54";
-		function = "gpio";
-		bias-pull-up;
-		drive-strength = <2>;
-	};
-};
-
-&sdc2_state_off {
-	sd-cd-pins {
-		pins = "gpio54";
-		function = "gpio";
-		bias-disable;
-		drive-strength = <2>;
-	};
-};
-
-&sdhc_1 {
-	supports-cqe;
-
-	mmc-hs200-1_8v;
-	mmc-hs400-1_8v;
-	mmc-hs400-enhanced-strobe;
-
-	vmmc-supply = <&vreg_l4b_2p95>;
-	vqmmc-supply = <&vreg_l8a_1p8>;
-
-	status = "okay";
-};
-
 &sdhc_2 {
-	cd-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
-	vmmc-supply = <&vreg_l5b_2p95>;
-	vqmmc-supply = <&vreg_l2b_2p95>;
-
 	status = "okay";
 };
 
 &tlmm {
-	gpio-reserved-ranges = <8 4>;
-
 	lcd_reset_active: lcd-reset-active-state {
 		function = "gpio";
 		pins = "gpio53";
@@ -665,13 +498,6 @@
 		bias-pull-down;
 	};
 
-	gpio_hall_sensor_default: gpio-hall-sensor-default-state {
-		pins = "gpio75";
-		function = "gpio";
-		drive-strength = <6>;
-		bias-pull-up;
-	};
-
 	synats_pins_active: ts-pins-active-state {
 		pins = "gpio66", "gpio67";
 		function = "gpio";
@@ -694,31 +520,3 @@
 	};
 };
 
-&usb3 {
-	qcom,select-utmi-as-pipe-clk;
-
-	status = "okay";
-};
-
-&usb3_dwc3 {
-	maximum-speed = "high-speed";
-	phys = <&qusb2phy0>;
-	phy-names = "usb2-phy";
-	dr_mode = "peripheral";
-};
-
-&venus {
-	firmware-name = "qcom/venus-4.4/venus.mdt";
-
-	status = "okay";
-};
-
-&wifi {
-	vdd-0.8-cx-mx-supply = <&vreg_l5a_0p848>;
-	vdd-1.8-xo-supply = <&vreg_l9a_1p8>;
-	vdd-1.3-rfa-supply = <&vreg_l6a_1p3>;
-	vdd-3.3-ch0-supply = <&vreg_l19a_3p3>;
-	vdd-3.3-ch1-supply = <&vreg_l19a_3p3>;
-
-	status = "okay";
-};

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -3,16 +3,8 @@
  * Copyright (c) 2020, Mark Hargreaves <clashclanacc2602@gmail.com>
  */
 
-/dts-v1/;
 #include "sdm660.dtsi"
-#include "pm660.dtsi"
-#include "pm660l.dtsi"
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/input/gpio-keys.h>
-#include <dt-bindings/leds/common.h>
-#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
-#include <dt-bindings/sound/qcom,q6afe.h>
-#include <dt-bindings/sound/qcom,q6asm.h>
+#include "sdm660-xiaomi-common.dtsi"
 
 /delete-node/ &adsp_region;
 /delete-node/ &cdsp_region;
@@ -21,17 +13,20 @@
 /delete-node/ &venus_region;
 
 / {
-	aliases {
-		serial0 = &blsp1_uart2; /* Debug UART */
-		serial1 = &blsp2_uart1; /* Bluetooth UART */
+	chassis-type = "tablet";
+
+	battery: battery {
+		compatible = "simple-battery";
+
+		charge-full-design-microamp-hours = <6000000>;
+		voltage-min-design-microvolt = <3400000>;
+		voltage-max-design-microvolt = <4400000>;
 	};
 
 	chosen {
 		#address-cells = <2>;
 		#size-cells = <2>;
 		ranges;
-
-		stdout-path = "serial0:115200n8";
 
 		framebuffer@9d400000 {
 			compatible = "simple-framebuffer";
@@ -76,44 +71,6 @@
 		enable-active-high;
 		pinctrl-names = "default";
 		pinctrl-0 = <&lcd_pwr_en_default>;
-	};
-
-	vph_pwr: vph-pwr-regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "vph_pwr";
-
-		regulator-always-on;
-		regulator-boot-on;
-	};
-
-	gpio-keys {
-		compatible = "gpio-keys";
-
-		pinctrl-0 = <&vol_up_default>;
-		pinctrl-names = "default";
-
-		key-volup {
-			label = "Volume Up";
-			gpios = <&pm660l_gpios 7 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_VOLUMEUP>;
-			debounce-interval = <15>;
-		};
-	};
-
-	gpio-hall-sensor {
-		compatible = "gpio-keys";
-
-		pinctrl-0 = <&gpio_hall_sensor_default>;
-		pinctrl-names = "default";
-
-		switch {
-			label = "Hall Effect Sensor";
-			gpios = <&tlmm 75 GPIO_ACTIVE_LOW>;
-			linux,input-type = <EV_SW>;
-			linux,code = <SW_LID>;
-			linux,can-disable;
-			wakeup-source;
-		};
 	};
 
 	reserved-memory {
@@ -163,65 +120,16 @@
 	};
 };
 
-&adreno_gpu {
-	status = "okay";
-};
-
 &adreno_gpu_zap {
-	firmware-name = "a512_zap.mdt";
+	firmware-name = "qcom/sdm660/xiaomi/clover/a512_zap.mdt";
 	memory-region = <&zap_shader_region>;
 };
 
-&blsp2_uart1 {
+&gpio_hall_sensor {
 	status = "okay";
-
-	bluetooth {
-		compatible = "qcom,wcn3990-bt";
-		vddxo-supply = <&vreg_l9a_1p8>;
-		vddrf-supply = <&vreg_l6a_1p3>;
-		vddch0-supply = <&vreg_l19a_3p3>;
-		vddio-supply = <&vreg_l13a_1p8>;
-		max-speed = <3200000>;
-	};
-};
-
-&mdss {
-	status = "okay";
-};
-
-&mmss_smmu {
-	status = "okay";
-};
-
-&q6afedai {
-	dai@81 {
-		reg = <INT0_MI2S_RX>;
-		qcom,sd-lines = <0 1>;
-	};
-
-	dai@88 {
-		reg = <INT3_MI2S_TX>;
-		qcom,sd-lines = <0 1>;
-	};
-};
-&q6asmdai {
-	dai@0 {
-		reg = <0>;
-	};
-	dai@1 {
-		reg = <1>;
-	};
 };
 
 &lpass_codec {
-	status = "okay";
-};
-&pm660l_codec {
-	vdd-micbias-supply = <&vreg_l7b_3p125>;
-
-	qcom,micbias-lvl = <2600>;
-	qcom,micbias1-ext-cap;
-
 	status = "okay";
 };
 
@@ -238,7 +146,7 @@
 	status = "okay";
 };
 
-&pm660_rradc {
+&pm660l_codec {
 	status = "okay";
 };
 
@@ -248,47 +156,93 @@
 		function = PMIC_GPIO_FUNC_NORMAL;
 		bias-disable;
 	};
-
-	vol_up_default: vol-up-default-state {
-		pins = "gpio7";
-		function = PMIC_GPIO_FUNC_NORMAL;
-		bias-pull-up;
-		input-enable;
-		qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
-	};
 };
 
 &pm660l_lpg {
-	qcom,power-source = <1>;
-
 	status = "okay";
+};
 
-	#address-cells = <1>;
-	#size-cells = <0>;
+&sdhc_2 {
+	status = "okay";
+};
 
-	led@3 {
-		reg = <3>;
-		color = <LED_COLOR_ID_WHITE>;
-		function = LED_FUNCTION_STATUS;
+&sound {
+	compatible = "qcom,sdm660-internal-sndcard";
+	model = "Xiaomi Mi Pad 4";
+	pinctrl-0 = <&cdc_pdm_default>,
+			<&cdc_dmic_default>;
+	pinctrl-names = "default";
+	audio-routing = "RX_BIAS", "Digital MCLK",
+			"INT_LDO_H", "Digital MCLK",
+			"Digital RX_I2S_CLK", "Digital MCLK",
+			"Digital TX_I2S_CLK", "Digital MCLK",
+			"Digital ADC1", "ADC1",
+			"Digital ADC2", "ADC2",
+			"Digital ADC3", "ADC3",
+			"PDM_RX1", "Digital PDM_RX1",
+			"PDM_RX2", "Digital PDM_RX2",
+			"PDM_RX3", "Digital PDM_RX3",
+			"Digital LPASS_PDM_TX", "PDM_TX",
+			"AMIC1", "MIC BIAS External1",
+			"AMIC2", "MIC BIAS External2";
+	mm1-dai-link {
+		link-name = "MultiMedia1";
+		cpu {
+			sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA1>;
+		};
+	};
+	mm2-dai-link {
+		link-name = "MultiMedia2";
+		cpu {
+			sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA2>;
+		};
+	};
+	int0-mi2s-dai-link {
+		link-name = "Internal MI2S Playback";
+		cpu {
+			sound-dai = <&q6afedai INT0_MI2S_RX>;
+		};
+		platform {
+			sound-dai = <&q6routing>;
+		};
+		codec {
+			sound-dai = <&pm660l_codec 0>,
+					<&lpass_codec 0>;
+		};
+	};
+
+	int3-mi2s-dai-link {
+		link-name = "Internal MI2S Capture";
+		cpu {
+			sound-dai = <&q6afedai INT3_MI2S_TX>;
+		};
+		platform {
+			sound-dai = <&q6routing>;
+		};
+		codec {
+			sound-dai = <&pm660l_codec 1>,
+					<&lpass_codec 1>;
+		};
 	};
 };
 
-&pon_pwrkey {
-	status = "okay";
-};
+/* Clover has different gpio-reserved-ranges */
+&tlmm {
+	gpio-reserved-ranges = <0 4>;
 
-&pon_resin {
-	linux,code = <KEY_VOLUMEDOWN>;
+	mdss_dsi_reset: mdss-dsi-reset-state {
+		pins = "gpio62";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+	};
 
-	status = "okay";
-};
-
-&qusb2phy0 {
-	vdd-supply = <&vreg_l1b_0p925>;
-	vdda-pll-supply = <&vreg_l10a_1p8>;
-	vdda-phy-dpdm-supply = <&vreg_l7b_3p125>;
-
-	status = "okay";
+	mdss_vsync_active: mdss-vsync-active-state {
+		pins = "gpio59";
+		function = "mdp_vsync";
+		drive-strength = <2>;
+		bias-pull-down;
+	};
 };
 
 &rpm_requests {
@@ -476,7 +430,6 @@
 			regulator-enable-ramp-delay = <250>;
 			regulator-ramp-delay = <0>;
 			regulator-allow-set-load;
-			/* regulator-always-on; */
 		};
 
 		vreg_l2a_1p0: l2 {
@@ -523,7 +476,6 @@
 			regulator-system-load = <325000>;
 			regulator-allow-set-load;
 		};
-
 
 		vreg_l9a_1p8: l9 {
 			regulator-min-microvolt = <1750000>;
@@ -607,157 +559,6 @@
 	};
 };
 
-&sdc2_state_on {
-	sd-cd-pins {
-		pins = "gpio54";
-		function = "gpio";
-		bias-pull-up;
-		drive-strength = <2>;
-	};
-};
-
-&sdc2_state_off {
-	sd-cd-pins {
-		pins = "gpio54";
-		function = "gpio";
-		bias-disable;
-		drive-strength = <2>;
-	};
-};
-
-&sdhc_1 {
-	supports-cqe;
-
-	mmc-hs200-1_8v;
-	mmc-hs400-1_8v;
-	mmc-hs400-enhanced-strobe;
-
-	vmmc-supply = <&vreg_l4b_2p95>;
-	vqmmc-supply = <&vreg_l8a_1p8>;
-
-	status = "okay";
-};
-
-&sdhc_2 {
-	cd-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
-
-	vmmc-supply = <&vreg_l5b_2p95>;
-	vqmmc-supply = <&vreg_l2b_2p95>;
-
-	status = "okay";
-};
-
-&sound {
-	compatible = "qcom,sdm660-internal-sndcard";
-	model = "Xiaomi Mi Pad 4";
-	pinctrl-0 = <&cdc_pdm_default>,
-			<&cdc_dmic_default>;
-	pinctrl-names = "default";
-	audio-routing = "RX_BIAS", "Digital MCLK",
-			"INT_LDO_H", "Digital MCLK",
-			"Digital RX_I2S_CLK", "Digital MCLK",
-			"Digital TX_I2S_CLK", "Digital MCLK",
-			"Digital ADC1", "ADC1",
-			"Digital ADC2", "ADC2",
-			"Digital ADC3", "ADC3",
-			"PDM_RX1", "Digital PDM_RX1",
-			"PDM_RX2", "Digital PDM_RX2",
-			"PDM_RX3", "Digital PDM_RX3",
-			"Digital LPASS_PDM_TX", "PDM_TX",
-			"AMIC1", "MIC BIAS External1",
-			"AMIC2", "MIC BIAS External2";
-	mm1-dai-link {
-		link-name = "MultiMedia1";
-		cpu {
-			sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA1>;
-		};
-	};
-	mm2-dai-link {
-		link-name = "MultiMedia2";
-		cpu {
-			sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA2>;
-		};
-	};
-	int0-mi2s-dai-link {
-		link-name = "Internal MI2S Playback";
-		cpu {
-			sound-dai = <&q6afedai INT0_MI2S_RX>;
-		};
-		platform {
-			sound-dai = <&q6routing>;
-		};
-		codec {
-			sound-dai = <&pm660l_codec 0>,
-					<&lpass_codec 0>;
-		};
-	};
-
-	int3-mi2s-dai-link {
-		link-name = "Internal MI2S Capture";
-		cpu {
-			sound-dai = <&q6afedai INT3_MI2S_TX>;
-		};
-		platform {
-			sound-dai = <&q6routing>;
-		};
-		codec {
-			sound-dai = <&pm660l_codec 1>,
-					<&lpass_codec 1>;
-		};
-	};
-};
-
-&tlmm {
-	gpio-reserved-ranges = <0 4>;
-
-	mdss_dsi_reset: mdss-dsi-reset-state {
-		pins = "gpio62";
-		function = "gpio";
-		drive-strength = <8>;
-		bias-disable;
-	};
-
-	mdss_vsync_active: mdss-vsync-active-state {
-		pins = "gpio59";
-		function = "mdp_vsync";
-		drive-strength = <2>;
-		bias-pull-down;
-	};
-
-	gpio_hall_sensor_default: gpio-hall-sensor-default-state {
-		pins = "gpio75";
-		function = "gpio";
-		drive-strength = <6>;
-		bias-pull-up;
-	};
-};
-
-&usb3 {
-	qcom,select-utmi-as-pipe-clk; /* Required if only USB 2.0 is available */
-
-	status = "okay";
-};
-
-&usb3_dwc3 {
-	maximum-speed = "high-speed";
-	phys = <&qusb2phy0>;
-	phy-names = "usb2-phy";
-	dr_mode = "peripheral";
-
-	status = "okay";
-};
-
-&venus {
-	firmware-name = "qcom/venus-4.4/venus.mdt";
-
-	status = "okay";
-};
-
 &wifi {
-	vdd-0.8-cx-mx-supply = <&vreg_l5a_0p848>;
-	vdd-1.8-xo-supply = <&vreg_l9a_1p8>;
-	vdd-1.3-rfa-supply = <&vreg_l6a_1p3>;
-	vdd-3.3-ch0-supply = <&vreg_l19a_3p3>;
-
-	status = "okay";
+	vdd-3.3-ch1-supply = <&vreg_l8b_3p3>;
 };

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-common.dtsi
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Common devicetree for Xiaomi SDM630/SDM636/SDM660 devices
+ */
+
+#include "pm660.dtsi"
+#include "pm660l.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/input/gpio-keys.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
+#include <dt-bindings/sound/qcom,q6afe.h>
+#include <dt-bindings/sound/qcom,q6asm.h>
+
+/ {
+	aliases {
+		serial0 = &blsp1_uart2; /* Debug UART */
+		serial1 = &blsp2_uart1; /* Bluetooth UART */
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		pinctrl-0 = <&vol_up_default>;
+		pinctrl-names = "default";
+
+		key-volup {
+			label = "Volume Up";
+			gpios = <&pm660l_gpios 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEUP>;
+			debounce-interval = <15>;
+		};
+	};
+
+	gpio_hall_sensor: gpio-hall-sensor {
+		compatible = "gpio-keys";
+
+		pinctrl-0 = <&gpio_hall_sensor_default>;
+		pinctrl-names = "default";
+
+		status = "disabled";
+
+		event-hall {
+			label = "Hall Effect Sensor";
+			gpios = <&tlmm 75 GPIO_ACTIVE_LOW>;
+			linux,input-type = <EV_SW>;
+			linux,code = <SW_LID>;
+			linux,can-disable;
+			wakeup-source;
+		};
+	};
+
+	vph_pwr: vph-pwr-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vph_pwr";
+		regulator-min-microvolt = <3700000>;
+		regulator-max-microvolt = <3700000>;
+
+		regulator-always-on;
+		regulator-boot-on;
+	};
+};
+
+&adreno_gpu {
+	status = "okay";
+};
+
+/* GPU zap shader firmware-name is set per-device */
+
+&blsp1_uart2 {
+	status = "okay";
+};
+
+&blsp2_uart1 {
+	status = "okay";
+
+	bluetooth {
+		compatible = "qcom,wcn3990-bt";
+		vddxo-supply = <&vreg_l9a_1p8>;
+		vddrf-supply = <&vreg_l6a_1p3>;
+		vddch0-supply = <&vreg_l19a_3p3>;
+		vddio-supply = <&vreg_l13a_1p8>;
+		max-speed = <3200000>;
+	};
+};
+
+&lpass_codec {
+	status = "disabled";
+};
+
+&mdss {
+	status = "okay";
+};
+
+&mmss_smmu {
+	status = "okay";
+};
+
+&pm660_charger {
+	status = "disabled";
+};
+
+&pm660_fg {
+	status = "disabled";
+};
+
+&pm660_haptics {
+	status = "okay";
+};
+
+&pm660_rradc {
+	status = "okay";
+};
+
+&pm660l_codec {
+	qcom,gnd-jack-type-normally-open;
+	qcom,hphl-jack-type-normally-open;
+	qcom,mbhc-vthreshold-high = <75 225 450 500 500>;
+	qcom,mbhc-vthreshold-low = <75 225 450 500 500>;
+	qcom,micbias1-ext-cap;
+	qcom,micbias-lvl = <2600>;
+
+	vdd-cdc-io-supply = <&vreg_s4a_2p04>;
+	vdd-cdc-tx-rx-cx-supply = <&vreg_s4a_2p04>;
+	vdd-micbias-supply = <&vreg_l7b_3p125>;
+
+	status = "disabled";
+};
+
+&pm660l_gpios {
+	vol_up_default: vol-up-default-state {
+		pins = "gpio7";
+		function = PMIC_GPIO_FUNC_NORMAL;
+		bias-pull-up;
+		input-enable;
+		qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
+	};
+};
+
+&pm660l_lpg {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	qcom,power-source = <1>;
+
+	status = "disabled";
+
+	led@3 {
+		reg = <3>;
+		color = <LED_COLOR_ID_WHITE>;
+		function = LED_FUNCTION_STATUS;
+	};
+};
+
+&pm660l_wled {
+	qcom,switching-freq = <800>;
+	qcom,current-limit-microamp = <20000>;
+	qcom,num-strings = <2>;
+
+	status = "disabled";
+};
+
+&pon_pwrkey {
+	status = "okay";
+};
+
+&pon_resin {
+	linux,code = <KEY_VOLUMEDOWN>;
+
+	status = "okay";
+};
+
+&q6afedai {
+	dai@81 {
+		reg = <INT0_MI2S_RX>;
+		qcom,sd-lines = <0 1>;
+	};
+
+	dai@88 {
+		reg = <INT3_MI2S_TX>;
+		qcom,sd-lines = <0 1>;
+	};
+};
+
+&q6asmdai {
+	dai@0 {
+		reg = <0>;
+	};
+
+	dai@1 {
+		reg = <1>;
+	};
+};
+
+&qusb2phy0 {
+	vdd-supply = <&vreg_l1b_0p925>;
+	vdda-pll-supply = <&vreg_l10a_1p8>;
+	vdda-phy-dpdm-supply = <&vreg_l7b_3p125>;
+
+	status = "okay";
+};
+
+&remoteproc_mss {
+	firmware-name = "mba.mbn", "modem.mdt";
+
+	status = "okay";
+};
+
+&sdc2_state_on {
+	sd-cd-pins {
+		pins = "gpio54";
+		function = "gpio";
+		bias-pull-up;
+		drive-strength = <2>;
+	};
+};
+
+&sdc2_state_off {
+	sd-cd-pins {
+		pins = "gpio54";
+		function = "gpio";
+		bias-disable;
+		drive-strength = <2>;
+	};
+};
+
+&sdhc_1 {
+	supports-cqe;
+
+	mmc-hs200-1_8v;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
+
+	vmmc-supply = <&vreg_l4b_2p95>;
+	vqmmc-supply = <&vreg_l8a_1p8>;
+
+	status = "okay";
+};
+
+&sdhc_2 {
+	cd-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
+	vmmc-supply = <&vreg_l5b_2p95>;
+	vqmmc-supply = <&vreg_l2b_2p95>;
+
+	status = "disabled";
+};
+
+&tlmm {
+	gpio-reserved-ranges = <8 4>;
+
+	gpio_hall_sensor_default: gpio-hall-sensor-default-state {
+		pins = "gpio75";
+		function = "gpio";
+		drive-strength = <6>;
+		bias-pull-up;
+	};
+};
+
+&usb3 {
+	qcom,select-utmi-as-pipe-clk;
+
+	status = "okay";
+};
+
+&usb3_dwc3 {
+	maximum-speed = "high-speed";
+	phys = <&qusb2phy0>;
+	phy-names = "usb2-phy";
+	dr_mode = "peripheral";
+};
+
+&venus {
+	firmware-name = "qcom/venus-4.4/venus.mdt";
+
+	status = "okay";
+};
+
+&wifi {
+	vdd-0.8-cx-mx-supply = <&vreg_l5a_0p848>;
+	vdd-1.8-xo-supply = <&vreg_l9a_1p8>;
+	vdd-1.3-rfa-supply = <&vreg_l6a_1p3>;
+	vdd-3.3-ch0-supply = <&vreg_l19a_3p3>;
+
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
@@ -6,38 +6,12 @@
 /dts-v1/;
 
 #include "sdm660.dtsi"
-#include "pm660.dtsi"
-#include "pm660l.dtsi"
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/input/gpio-keys.h>
-#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
+#include "sdm660-xiaomi-common.dtsi"
 
 / {
 	model = "Xiaomi Mi A2";
 	compatible = "xiaomi,jasmine", "qcom,sdm660";
 	chassis-type = "handset";
-
-	aliases {
-		serial0 = &blsp1_uart2; /* Debug UART */
-		serial1 = &blsp2_uart1; /* Bluetooth UART */
-	};
-
-	chosen {
-		#address-cells = <2>;
-		#size-cells = <2>;
-		ranges;
-
-		stdout-path = "serial0:115200n8";
-
-		framebuffer0: framebuffer@9d400000 {
-			compatible = "simple-framebuffer";
-			reg = <0 0x9d400000 0 (1080 * 2160 * 4)>;
-			width = <1080>;
-			height = <2160>;
-			stride = <(1080 * 4)>;
-			format = "a8r8g8b8";
-		};
-	};
 
 	battery: battery {
 		compatible = "simple-battery";
@@ -47,44 +21,18 @@
 		voltage-max-design-microvolt = <4400000>;
 	};
 
-	vph_pwr: vph-pwr-regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "vph_pwr";
-		regulator-min-microvolt = <3700000>;
-		regulator-max-microvolt = <3700000>;
+	chosen {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
 
-		regulator-always-on;
-		regulator-boot-on;
-	};
-
-	/*
-	 * This is here until we have a driver for QPNP LCDB regulator.
-	 * It can emulate both positive LDO and negative NCP supplies for panel.
-	 */
-	lcdb_fixed: lcdb-regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "lcdb";
-		/*
-		 * Actual range for LCDB is 4.0 - 6.0V, but
-		 * stock bootloader sets voltage to 5.4 V
-		 */
-		regulator-min-microvolt = <5400000>;
-		regulator-max-microvolt = <5400000>;
-		regulator-always-on;
-		regulator-boot-on;
-	};
-
-	gpio-keys {
-		compatible = "gpio-keys";
-
-		pinctrl-0 = <&vol_up_default>;
-		pinctrl-names = "default";
-
-		key-volup {
-			label = "Volume Up";
-			gpios = <&pm660l_gpios 7 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_VOLUMEUP>;
-			debounce-interval = <15>;
+		framebuffer0: framebuffer@9d400000 {
+			compatible = "simple-framebuffer";
+			reg = <0 0x9d400000 0 (1080 * 2160 * 4)>;
+			width = <1080>;
+			height = <2160>;
+			stride = <(1080 * 4)>;
+			format = "a8r8g8b8";
 		};
 	};
 
@@ -109,6 +57,23 @@
 	};
 
 	/*
+	 * This is here until we have a driver for QPNP LCDB regulator.
+	 * It can emulate both positive LDO and negative NCP supplies for panel.
+	 */
+	lcdb_fixed: lcdb-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "lcdb";
+		/*
+		 * Actual range for LCDB is 4.0 - 6.0V, but
+		 * stock bootloader sets voltage to 5.4 V
+		 */
+		regulator-min-microvolt = <5400000>;
+		regulator-max-microvolt = <5400000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
+	/*
 	 * Until we hook up type-c detection, we
 	 * have to stick with this. But it works.
 	 */
@@ -118,31 +83,8 @@
 	};
 };
 
-&adreno_gpu {
-	status = "okay";
-};
-
 &adreno_gpu_zap {
-	firmware-name = "a512_zap.mbn";
-};
-
-&blsp1_uart2 {
-	status = "okay";
-};
-
-&blsp2_uart1 {
-	status = "okay";
-
-	bluetooth {
-		compatible = "qcom,wcn3990-bt";
-		vddxo-supply = <&vreg_l9a_1p8>; // downstream: vdd-core-supply
-		vddrf-supply = <&vreg_l6a_1p3>; // vdd-pa-supply
-		vddch0-supply = <&vreg_l19a_3p3>; // vdd-ldo-supply
-		vddio-supply = <&vreg_l13a_1p8>; // chip-pwd-supply ? // TODO: check
-		max-speed = <3200000>;
-		/* Path is relative to the qca/ subdir in lib/firmware. */
-		/* firmware-name = "crnv21.bin"; */ // default
-	};
+	firmware-name = "qcom/sdm660/xiaomi/jasmine/a512_zap.mdt";
 };
 
 &blsp_i2c1 {
@@ -161,10 +103,6 @@
 		touchscreen-size-x = <1080>;
 		touchscreen-size-y = <2160>;
 	};
-};
-
-&mdss {
-	status = "okay";
 };
 
 &mdss_dsi0 {
@@ -210,10 +148,6 @@
 	status = "okay";
 };
 
-&mmss_smmu {
-	status = "okay";
-};
-
 &pm660_charger {
 	monitored-battery = <&battery>;
 
@@ -227,53 +161,7 @@
 	status = "okay";
 };
 
-&pm660_haptics {
-	status = "okay";
-};
-
-&pm660_rradc {
-	status = "okay";
-};
-
-&pm660l_gpios {
-	vol_up_default: vol-up-default-state {
-		pins = "gpio7";
-		function = PMIC_GPIO_FUNC_NORMAL;
-		bias-pull-up;
-		input-enable;
-		qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
-	};
-};
-
 &pm660l_wled {
-	qcom,switching-freq = <800>;
-	qcom,current-limit-microamp = <20000>;
-	qcom,num-strings = <2>;
-
-	status = "okay";
-};
-
-&pon_pwrkey {
-	status = "okay";
-};
-
-&pon_resin {
-	linux,code = <KEY_VOLUMEDOWN>;
-
-	status = "okay";
-};
-
-&qusb2phy0 {
-	vdd-supply = <&vreg_l1b_0p925>;
-	vdda-pll-supply = <&vreg_l10a_1p8>;
-	vdda-phy-dpdm-supply = <&vreg_l7b_3p125>;
-
-	status = "okay";
-};
-
-&remoteproc_mss {
-	firmware-name = "mba.mbn", "modem.mdt";
-
 	status = "okay";
 };
 
@@ -532,40 +420,7 @@
 	};
 };
 
-&sdc2_state_on {
-	sd-cd-pins {
-		pins = "gpio54";
-		function = "gpio";
-		bias-pull-up;
-		drive-strength = <2>;
-	};
-};
-
-&sdc2_state_off {
-	sd-cd-pins {
-		pins = "gpio54";
-		function = "gpio";
-		bias-disable;
-		drive-strength = <2>;
-	};
-};
-
-&sdhc_1 {
-	supports-cqe;
-
-	mmc-hs200-1_8v;
-	mmc-hs400-1_8v;
-	mmc-hs400-enhanced-strobe;
-
-	vmmc-supply = <&vreg_l4b_2p95>;
-	vqmmc-supply = <&vreg_l8a_1p8>;
-
-	status = "okay";
-};
-
 &tlmm {
-	gpio-reserved-ranges = <8 4>;
-
 	ts_pins_active: ts-pins-active-state {
 		pins = "gpio66", "gpio67";
 		function = "gpio";
@@ -602,30 +457,6 @@
 	};
 };
 
-&usb3 {
-	qcom,select-utmi-as-pipe-clk;
-
-	status = "okay";
-};
-
 &usb3_dwc3 {
-	maximum-speed = "high-speed";
-	phys = <&qusb2phy0>;
-	phy-names = "usb2-phy";
-
-	dr_mode = "peripheral";
 	extcon = <&extcon_usb>;
-};
-
-&venus {
-	status = "okay";
-};
-
-&wifi {
-	vdd-0.8-cx-mx-supply = <&vreg_l5a_0p848>;
-	vdd-1.8-xo-supply = <&vreg_l9a_1p8>;
-	vdd-1.3-rfa-supply = <&vreg_l6a_1p3>;
-	vdd-3.3-ch0-supply = <&vreg_l19a_3p3>;
-
-	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
@@ -4,17 +4,8 @@
  * Copyright (c) 2021, Dang Huynh <danct12@riseup.net>
  */
 
-/dts-v1/;
-
 #include "sdm660.dtsi"
-#include "pm660.dtsi"
-#include "pm660l.dtsi"
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/input/gpio-keys.h>
-#include <dt-bindings/leds/common.h>
-#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
-#include <dt-bindings/sound/qcom,q6afe.h>
-#include <dt-bindings/sound/qcom,q6asm.h>
+#include "sdm660-xiaomi-common.dtsi"
 
 /delete-node/ &zap_shader_region;
 
@@ -23,17 +14,10 @@
 	compatible = "xiaomi,lavender", "qcom,sdm660";
 	chassis-type = "handset";
 
-	aliases {
-		serial0 = &blsp1_uart2; /* Debug UART */
-		serial1 = &blsp2_uart1; /* Bluetooth UART */
-	};
-
 	chosen {
 		#address-cells = <2>;
 		#size-cells = <2>;
 		ranges;
-
-		stdout-path = "serial0:115200n8";
 
 		framebuffer0: framebuffer@9d400000 {
 			compatible = "simple-framebuffer";
@@ -53,16 +37,6 @@
 		voltage-max-design-microvolt = <4400000>;
 	};
 
-	vph_pwr: vph-pwr-regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "vph_pwr";
-		regulator-min-microvolt = <3700000>;
-		regulator-max-microvolt = <3700000>;
-
-		regulator-always-on;
-		regulator-boot-on;
-	};
-
 	/*
 	 * This is here until we have a driver for QPNP LCDB regulator.
 	 * It can emulate both positive LDO and negative NCP supplies for panel.
@@ -78,20 +52,6 @@
 		regulator-max-microvolt = <5400000>;
 		regulator-always-on;
 		regulator-boot-on;
-	};
-
-	gpio-keys {
-		compatible = "gpio-keys";
-
-		pinctrl-0 = <&vol_up_default>;
-		pinctrl-names = "default";
-
-		key-volup {
-			label = "Volume Up";
-			gpios = <&pm660l_gpios 7 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_VOLUMEUP>;
-			debounce-interval = <15>;
-		};
 	};
 
 	reserved-memory {
@@ -122,6 +82,7 @@
 			no-map;
 		};
 	};
+
 	/*
 	 * Until we hook up type-c detection, we
 	 * have to stick with this. But it works.
@@ -132,35 +93,12 @@
 	};
 };
 
-&adreno_gpu {
-	status = "okay";
-};
-
 &adreno_gpu_zap {
-	firmware-name = "a512_zap.mbn";
+	firmware-name = "qcom/sdm660/xiaomi/lavender/a512_zap.mdt";
 	memory-region = <&zap_shader_region>;
 };
 
-&blsp1_uart2 {
-	status = "okay";
-};
-
-&blsp2_uart1 {
-	status = "okay";
-
-	bluetooth {
-		compatible = "qcom,wcn3990-bt";
-		vddxo-supply = <&vreg_l9a_1p8>; // downstream: vdd-core-supply
-		vddrf-supply = <&vreg_l6a_1p3>; // vdd-pa-supply
-		vddch0-supply = <&vreg_l19a_3p3>; // vdd-ldo-supply
-		vddio-supply = <&vreg_l13a_1p8>; // chip-pwd-supply ? // TODO: check
-		max-speed = <3200000>;
-		/* Path is relative to the qca/ subdir in lib/firmware. */
-		/* firmware-name = "crnv21.bin"; */ // default
-	};
-};
-
-&mdss {
+&lpass_codec {
 	status = "okay";
 };
 
@@ -201,20 +139,11 @@
 	status = "okay";
 };
 
-&mmss_smmu {
-	status = "okay";
-};
-
 &pm660_charger {
 	monitored-battery = <&battery>;
 
 	status = "okay";
 };
-
-&lpass_codec {
-	status = "okay";
-};
-
 
 &pm660_fg {
 	monitored-battery = <&battery>;
@@ -223,102 +152,102 @@
 	status = "okay";
 };
 
-&pm660_haptics {
-	status = "okay";
-};
-
-&pm660_rradc {
-	status = "okay";
-};
-
-&pm660l_gpios {
-	vol_up_default: vol-up-default-state {
-		pins = "gpio7";
-		function = PMIC_GPIO_FUNC_NORMAL;
-		bias-pull-up;
-		input-enable;
-		qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
-	};
-};
-
 &pm660l_lpg {
-	#address-cells = <1>;
-	#size-cells = <0>;
-	qcom,power-source = <1>;
-
 	status = "okay";
-
-	/* White LED is connected to red channel */
-	led@3 {
-		reg = <3>;
-		color = <LED_COLOR_ID_WHITE>;
-		function = LED_FUNCTION_STATUS;
-	};
 };
 
 &pm660l_wled {
-	qcom,switching-freq = <800>;
-	qcom,current-limit-microamp = <20000>;
-	qcom,num-strings = <2>;
-
 	status = "okay";
 };
 
 &pm660l_codec {
-	vdd-cdc-io-supply = <&vreg_s4a_2p04>;
-	vdd-cdc-tx-rx-cx-supply = <&vreg_s4a_2p04>;
-	vdd-micbias-supply = <&vreg_l7b_3p125>;
-
-	qcom,micbias-lvl = <2600>;
-	qcom,micbias1-ext-cap;
-
 	status = "okay";
 };
 
-&pon_pwrkey {
+&sdhc_2 {
 	status = "okay";
 };
 
-&pon_resin {
-	linux,code = <KEY_VOLUMEDOWN>;
+&sound {
+	compatible = "qcom,sdm660-internal-sndcard";
+	model = "Xiaomi Redmi Note 7";
 
-	status = "okay";
-};
+	pinctrl-0 = <&cdc_pdm_default>,
+			<&cdc_dmic_default>;
+	pinctrl-names = "default";
 
-&q6afedai {
-	dai@81 {
-		reg = <INT0_MI2S_RX>;
-		qcom,sd-lines = <0 1>;
+	audio-routing = "PDM_RX1", "Digital PDM_RX1",
+			"PDM_RX2", "Digital PDM_RX2",
+			"PDM_RX3", "Digital PDM_RX3",
+			"Digital LPASS_PDM_TX", "PDM_TX",
+			"AMIC1", "MIC BIAS External1",
+			"AMIC2", "MIC BIAS External2";
+
+	mm1-dai-link {
+		link-name = "MultiMedia1";
+
+		cpu {
+			sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA1>;
+		};
 	};
 
-	dai@88 {
-		reg = <INT3_MI2S_TX>;
-		qcom,sd-lines = <0 1>;
+	mm2-dai-link {
+		link-name = "MultiMedia2";
+
+		cpu {
+			sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA2>;
+		};
+	};
+
+	int0-mi2s-dai-link {
+		link-name = "Internal MI2S Playback";
+
+		cpu {
+			sound-dai = <&q6afedai INT0_MI2S_RX>;
+		};
+
+		platform {
+			sound-dai = <&q6routing>;
+		};
+
+		codec {
+			sound-dai = <&pm660l_codec 0>,
+					<&lpass_codec 0>;
+		};
+	};
+
+	int3-mi2s-dai-link {
+		link-name = "Internal MI2S Capture";
+
+		cpu {
+			sound-dai = <&q6afedai INT3_MI2S_TX>;
+		};
+
+		platform {
+			sound-dai = <&q6routing>;
+		};
+
+		codec {
+			sound-dai = <&pm660l_codec 1>,
+					<&lpass_codec 1>;
+		};
 	};
 };
 
-&q6asmdai {
-	dai@0 {
-		reg = <0>;
+&tlmm {
+	mdss_dsi_active: mdss-dsi-active-state {
+		function = "gpio";
+		pins = "gpio53";
+		drive-strength = <8>;
+		bias-disable;
 	};
 
-	dai@1 {
-		reg = <1>;
+	mdss_te_active: mdss-te-active-state {
+		pins = "gpio59";
+		function = "mdp_vsync";
+		drive-strength = <2>;
+		bias-pull-down;
 	};
-};
-
-&qusb2phy0 {
-	vdd-supply = <&vreg_l1b_0p925>;
-	vdda-pll-supply = <&vreg_l10a_1p8>;
-	vdda-phy-dpdm-supply = <&vreg_l7b_3p125>;
-
-	status = "okay";
-};
-
-&remoteproc_mss {
-	firmware-name = "mba.mbn", "modem.mdt";
-
-	status = "okay";
 };
 
 &rpm_requests {
@@ -575,153 +504,6 @@
 	};
 };
 
-&sdc2_state_on {
-	sd-cd-pins {
-		pins = "gpio54";
-		function = "gpio";
-		bias-pull-up;
-		drive-strength = <2>;
-	};
-};
-
-&sdc2_state_off {
-	sd-cd-pins {
-		pins = "gpio54";
-		function = "gpio";
-		bias-disable;
-		drive-strength = <2>;
-	};
-};
-
-&sdhc_1 {
-	status = "okay";
-	supports-cqe;
-
-	mmc-hs200-1_8v;
-	mmc-hs400-1_8v;
-	mmc-hs400-enhanced-strobe;
-
-	vmmc-supply = <&vreg_l4b_2p95>;
-	vqmmc-supply = <&vreg_l8a_1p8>;
-};
-
-&sdhc_2 {
-	status = "okay";
-
-	cd-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
-
-	vmmc-supply = <&vreg_l5b_2p95>;
-	vqmmc-supply = <&vreg_l2b_2p95>;
-};
-
-&sound {
-	compatible = "qcom,sdm660-internal-sndcard";
-	model = "Xiaomi Redmi Note 7";
-
-	pinctrl-0 = <&cdc_pdm_default>,
-			<&cdc_dmic_default>;
-	pinctrl-names = "default";
-
-	audio-routing = "PDM_RX1", "Digital PDM_RX1",
-			"PDM_RX2", "Digital PDM_RX2",
-			"PDM_RX3", "Digital PDM_RX3",
-			"Digital LPASS_PDM_TX", "PDM_TX",
-			"AMIC1", "MIC BIAS External1",
-			"AMIC2", "MIC BIAS External2";
-
-	mm1-dai-link {
-		link-name = "MultiMedia1";
-
-		cpu {
-			sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA1>;
-		};
-	};
-
-	mm2-dai-link {
-		link-name = "MultiMedia2";
-
-		cpu {
-			sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA2>;
-		};
-	};
-
-	int0-mi2s-dai-link {
-		link-name = "Internal MI2S Playback";
-
-		cpu {
-			sound-dai = <&q6afedai INT0_MI2S_RX>;
-		};
-
-		platform {
-			sound-dai = <&q6routing>;
-		};
-
-		codec {
-			sound-dai = <&pm660l_codec 0>,
-					<&lpass_codec 0>;
-		};
-	};
-
-	int3-mi2s-dai-link {
-		link-name = "Internal MI2S Capture";
-
-		cpu {
-			sound-dai = <&q6afedai INT3_MI2S_TX>;
-		};
-
-		platform {
-			sound-dai = <&q6routing>;
-		};
-
-		codec {
-			sound-dai = <&pm660l_codec 1>,
-					<&lpass_codec 1>;
-		};
-	};
-};
-
-&tlmm {
-	gpio-reserved-ranges = <8 4>;
-
-	mdss_dsi_active: mdss-dsi-active-state {
-		function = "gpio";
-		pins = "gpio53";
-		drive-strength = <8>;
-		bias-disable;
-	};
-
-	mdss_te_active: mdss-te-active-state {
-		pins = "gpio59";
-		function = "mdp_vsync";
-		drive-strength = <2>;
-		bias-pull-down;
-	};
-};
-
-&usb3 {
-	qcom,select-utmi-as-pipe-clk;
-
-	status = "okay";
-};
-
 &usb3_dwc3 {
-	maximum-speed = "high-speed";
-	phys = <&qusb2phy0>;
-	phy-names = "usb2-phy";
-
-	dr_mode = "peripheral";
 	extcon = <&extcon_usb>;
-};
-
-&venus {
-	status = "okay";
-};
-
-&wifi {
-	vdd-0.8-cx-mx-supply = <&vreg_l5a_0p848>;
-	vdd-1.8-xo-supply = <&vreg_l9a_1p8>;
-	vdd-1.3-rfa-supply = <&vreg_l6a_1p3>;
-	vdd-3.3-ch0-supply = <&vreg_l19a_3p3>;
-
-	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-platina.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-platina.dts
@@ -8,26 +8,19 @@
 /dts-v1/;
 
 #include "sdm660.dtsi"
-#include "pm660.dtsi"
-#include "pm660l.dtsi"
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/input/gpio-keys.h>
-#include <dt-bindings/leds/common.h>
-#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
+#include "sdm660-xiaomi-common.dtsi"
 
 / {
 	model = "Xiaomi Mi 8 Lite";
 	compatible = "xiaomi,platina", "qcom,sdm660";
 	chassis-type = "handset";
 
+	/* Override aliases - platina only has serial0 */
 	aliases {
-		serial0 = &blsp1_uart2;
+		/delete-property/ serial1;
 	};
 
 	chosen {
-		stdout-path = "serial0:115200n8";
-
 		#address-cells = <2>;
 		#size-cells = <2>;
 		ranges;
@@ -183,48 +176,6 @@
 		pinctrl-0 = <&ts_vdd_default>;
 	};
 
-	vph_pwr: vph-pwr-regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "vph_pwr";
-
-		regulator-always-on;
-		regulator-boot-on;
-	};
-
-	gpio_keys {
-		status = "okay";
-		compatible = "gpio-keys";
-		label = "Volume up";
-		pinctrl-names = "default";
-		pinctrl-0 = <&vol_up_gpio_default>;
-
-		key-vol-up {
-			label = "Volume Up";
-			gpios = <&pm660l_gpios 7 GPIO_ACTIVE_LOW>;
-			linux,input-type = <EV_KEY>;
-			linux,code = <KEY_VOLUMEUP>;
-			debounce-interval = <15>;
-		};
-	};
-
-	gpio-hall-sensor {
-		compatible = "gpio-keys";
-		label = "Hall effect sensor";
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&hall_sensor_default>;
-
-		switch {
-			label = "Hall Effect Sensor";
-			gpios = <&tlmm 75 GPIO_ACTIVE_LOW>;
-			linux,input-type = <EV_SW>;
-			linux,code = <SW_LID>;
-			linux,can-disable;
-			wakeup-source;
-		};
-	};
-
-
 	/*
 	 * Until we hook up type-c detection, we
 	 * have to stick with this. But it works.
@@ -235,8 +186,13 @@
 	};
 };
 
+/* platina has GPU disabled */
 &adreno_gpu {
 	status = "disabled";
+};
+
+&adreno_gpu_zap {
+	firmware-name = "qcom/sdm660/xiaomi/platina/a512_zap.mdt";
 };
 
 &blsp_i2c2 {
@@ -265,7 +221,15 @@
 	};
 };
 
-&blsp1_uart2 {
+/* No bluetooth UART on platina */
+&blsp2_uart1 {
+	/delete-node/ bluetooth;
+};
+
+&gpio_hall_sensor {
+	label = "Hall effect sensor";
+	pinctrl-0 = <&hall_sensor_default>;
+
 	status = "okay";
 };
 
@@ -301,30 +265,10 @@
 		output-low;
 		power-source = <0>;
 	};
-
-	vol_up_gpio_default: vol-up-gpio-default-state {
-		pins = "gpio7";
-		function = "normal";
-		bias-pull-up;
-		input-enable;
-		qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
-	};
 };
 
-&pon_resin {
-	linux,code = <KEY_VOLUMEDOWN>;
-
-	status = "okay";
-};
-
-&pon_pwrkey {
-	status = "okay";
-};
-
-&qusb2phy0 {
-	vdd-supply = <&vreg_l1b_0p925>;
-	vdda-pll-supply = <&vreg_l10a_1p8>;
-	vdda-phy-dpdm-supply = <&vreg_l7b_3p125>;
+&pm660l_wled {
+	default-brightness = <512>;
 
 	status = "okay";
 };
@@ -638,19 +582,6 @@
 	};
 };
 
-&sdhc_1 {
-	supports-cqe;
-
-	mmc-ddr-1_8v;
-	mmc-hs400-1_8v;
-	mmc-hs400-enhanced-strobe;
-
-	vmmc-supply = <&vreg_l4b_2p95>;
-	vqmmc-supply = <&vreg_l8a_1p8>;
-
-	status = "okay";
-};
-
 &sdhc_2 {
 	vmmc-supply = <&vreg_l5b_29p5>;
 	vqmmc-supply = <&vreg_l2b_2p95>;
@@ -659,8 +590,6 @@
 };
 
 &tlmm {
-	gpio-reserved-ranges = <8 4>;
-
 	camera_rear_default: camera-rear-default-state {
 		mclk0-pins {
 			pins = "gpio32";
@@ -772,20 +701,8 @@
 		bias-disable;
 		output-disable;
 	};
-
-};
-
-&usb3 {
-	qcom,select-utmi-as-pipe-clk;
-
-	status = "okay";
 };
 
 &usb3_dwc3 {
-	maximum-speed = "high-speed";
-	phys = <&qusb2phy0>;
-	phy-names = "usb2-phy";
-
-	dr_mode = "peripheral";
 	extcon = <&extcon_usb>;
 };


### PR DESCRIPTION
This patch creates a common devicetree include file for Xiaomi devices based on SDM630/SDM636/SDM660 SoCs, reducing code duplication across 6 device trees.

  Affected devices:
  - sdm636-xiaomi-tulip (Redmi Note 6 Pro)
  - sdm636-xiaomi-whyred (Redmi Note 5 Pro)
  - sdm660-xiaomi-jasmine (Mi A2)
  - sdm660-xiaomi-platina (Mi 8 Lite)
  - sdm660-xiaomi-lavender (Redmi Note 7)
  - sdm660-xiaomi-clover (Mi Pad 4 / Mi Pad 4 Plus)

  The common file includes shared configuration for:
  - PM660/PM660L regulators
  - GPIO keys, hall sensor, PON keys
  - USB, WiFi, Bluetooth (wcn3990)
  - eMMC/SD card
  - Audio DAI configuration
  - GPU, display (MDSS), Venus
  - Modem

  Device-specific elements (battery, panel, touchscreen, reserved-memory, regulator voltages) remain in individual device files.