### PR TITLE
Add support for battery for pioneer

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-sony-xperia-nile-pioneer.dts
+++ b/arch/arm64/boot/dts/qcom/sdm630-sony-xperia-nile-pioneer.dts
@@ -22,6 +22,15 @@
 			no-map;
 		};
 	};
+
+	/* Either tdk_4380mv or send_4380mv, both similar */
+	battery: battery {
+		compatible = "simple-battery";
+
+		charge-full-design-microamp-hours = <3300000>;
+		voltage-min-design-microvolt = <3400000>;
+		voltage-max-design-microvolt = <4380000>;
+	};
 };
 
 &adreno_gpu {
@@ -78,6 +87,23 @@
 };
 
 &mmss_smmu {
+	status = "okay";
+};
+
+&pm660_charger {
+	monitored-battery = <&battery>;
+
+	status = "okay";
+};
+
+&pm660_fg {
+	monitored-battery = <&battery>;
+	power-supplies = <&pm660_charger>;
+
+	status = "okay";
+};
+
+&pm660_rradc {
 	status = "okay";
 };
 


### PR DESCRIPTION
Add support for battery, fuelgauge and charger. Source: downstream [1]

[1] https://github.com/LineageOS/android_kernel_sony_sdm660/commit/9b87354d6b2f37fc3057dfa35e873ec30f9c4365

Tired of looking at red exclamation mark instead of battery percentage, looks better now 

<img width="960" height="1280" alt="image" src="https://github.com/user-attachments/assets/360b1830-f268-495d-81c9-323ba9ca51ca" />
