### PR TITLE
arm64: dts: qcom: sdm660: align GPU firmware paths for postmarketOS

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm630-nokia-pl2.dts
+++ b/arch/arm64/boot/dts/qcom/sdm630-nokia-pl2.dts
@@ -187,7 +187,7 @@
 };
 
 &adreno_gpu_zap {
-	firmware-name = "a508_zap.mbn";
+	firmware-name = "qcom/sdm630/nokia/pl2/a508_zap.mdt";
 	memory-region = <&zap_shader_region>;
 };
 

--- a/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-asus-x00td.dts
@@ -184,7 +184,7 @@
 
 &adreno_gpu_zap {
 	memory-region = <&zap_shader_region>;
-	firmware-name = "a512_zap.mbn";
+	firmware-name = "qcom/sdm636/asus/x00td/a512_zap.mdt";
 };
 
 &adsp_pil {

--- a/arch/arm64/boot/dts/qcom/sdm636-bbry-luna-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm636-bbry-luna-common.dtsi
@@ -20,7 +20,7 @@
 };
 
 &adreno_gpu_zap {
-	firmware-name = "qcom/sdm636/luna/a512_zap.mbn";
+	firmware-name = "qcom/sdm636/luna/a512_zap.mdt";
 };
 
 &adsp_pil {

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -132,7 +132,7 @@
 };
 
 &adreno_gpu_zap {
-	firmware-name = "a512_zap.mbn";
+	firmware-name = "qcom/sdm636/xiaomi/tulip/a512_zap.mdt";
 };
 
 &blsp_i2c1 {

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-whyred.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-whyred.dts
@@ -152,7 +152,7 @@
 };
 
 &adreno_gpu_zap {
-	firmware-name = "a512_zap.mbn";
+	firmware-name = "qcom/sdm636/xiaomi/whyred/a512_zap.mdt";
 	memory-region = <&zap_shader_region>;
 };
 

--- a/arch/arm64/boot/dts/qcom/sdm660-bbry-athena-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-bbry-athena-common.dtsi
@@ -19,7 +19,7 @@
 };
 
 &adreno_gpu_zap {
-	firmware-name = "qcom/sdm660/athena/a512_zap.mbn";
+	firmware-name = "qcom/sdm660/athena/a512_zap.mdt";
 };
 
 &adsp_pil {


### PR DESCRIPTION
Update GPU ZAP shader firmware paths to align with the unified firmware-qcom-sdm660 package in postmarketOS:

- Use .mdt extension instead of .mbn (preferred by MDT loader)
- Use SoC-specific paths (sdm630/sdm636/sdm660) matching actual hardware
- Add device-specific paths for packaged firmware

Changes:
- sdm630-nokia-pl2: a508_zap.mbn -> qcom/sdm630/nokia/pl2/a508_zap.mdt
- sdm636-asus-x00td: a512_zap.mbn -> qcom/sdm636/asus/x00td/a512_zap.mdt
- sdm636-bbry-luna: a512_zap.mbn -> a512_zap.mdt
- sdm636-xiaomi-tulip: qcom/sdm660/ -> qcom/sdm636/
- sdm636-xiaomi-whyred: qcom/sdm660/ -> qcom/sdm636/
- sdm660-bbry-athena: a512_zap.mbn -> a512_zap.mdt