### PR TITLE
sns_reg fix

### DIFF
--- a/drivers/soc/qcom/qcom_sns_reg.c
+++ b/drivers/soc/qcom/qcom_sns_reg.c
@@ -573,6 +573,13 @@ static int qcom_sns_reg_probe(struct auxiliary_device *auxdev,
 			refcount_set(&__qcom_sns_reg_data->refcnt, 1);
 
 			ret = qcom_sns_reg_probe_once(auxdev);
+			if (ret) {
+				/* Probe failed, probably because no firmware was found */
+				__qcom_sns_reg_data = NULL;
+				kfree(data);
+				mutex_unlock(&qcom_sns_reg_mutex);
+				return dev_err_probe(&auxdev->dev, ret, "qcom_sns_reg probe failed!");
+			}
 		}
 	} else {
 		/* For 2nd, 3rd,.. init just increase reference count */


### PR DESCRIPTION
Potential fix for nullptr deref if no sns.reg firmware was found at all. Previously, return error code from `qcom_sns_reg_probe_once()` was completely ignored, now failure is properly handled.

Untested (compile tested only), hard to test with our setup where msm-firmware-loader *always* finds `sns.reg` from persist partition