### PR TITLE
arm64: dts: qcom: sdm660-bbry-common: fix reserved-mem ranges, panel regulators, and syna ts

### DIFF
--- a/Documentation/devicetree/bindings/display/panel/boe,bv045fhm-l00.yaml
+++ b/Documentation/devicetree/bindings/display/panel/boe,bv045fhm-l00.yaml
@@ -26,6 +26,15 @@ properties:
   backlight:
     description: phandle of the backlight device attached to the panel
 
+  vddio-supply:
+    description: power IC supply regulator
+
+  vddpos-supply:
+    description: positive boost supply regulator
+
+  vddneg-supply:
+    description: negative boost supply regulator
+
   port: true
   rotation: true
   width-mm: true
@@ -35,35 +44,41 @@ required:
   - compatible
   - reg
   - reset-gpios
+  - vddio-supply
+  - vddpos-supply
+  - vddneg-supply
 
-unevalueatedProperties: false
+
+unevaluatedProperties: false
 
 examples:
   - |
-    #address-cells = <1>;
-    #size-cells = <0>;
+    #include <dt-bindings/gpio/gpio.h>
+    dsi {
+      #address-cells = <1>;
+      #size-cells = <0>;
+        panel: panel@0 {
+          compatible = "boe,bv045fhm-l00";
+          reg = <0>;
 
-    vdd-supply = <&vreg_l1b_0p925>;
-    vdda-supply = <&vreg_l1a_1p225>;
+          backlight = <&pm660l_wled>;
+          reset-gpios = <&tlmm 53 GPIO_ACTIVE_LOW>;
 
-    panel: panel@0 {
-      compatible = "boe,bv045fhm-l00";
-      reg = <0>;
+          vddio-supply = <&vreg_l11a_1p8>;
+          vddpos-supply = <&lab>;
+          vddneg-supply = <&ibb>;
 
-      backlight = <&pm660l_wled>;
-      reset-gpios = <&tlmm 53 GPIO_ACTIVE_LOW>;
+          pinctrl-0 = <&mdss_dsi_active &mdss_te_active>;
+          pinctrl-1 = <&mdss_dsi_sleep &mdss_te_sleep>;
+          pinctrl-names = "default", "sleep";
 
-      pinctrl-0 = <&mdss_dsi_active &mdss_te_active>;
-      pinctrl-1 = <&mdss_dsi_sleep &mdss_te_sleep>;
-      pinctrl-names = "default", "sleep";
+          width-mm = <63>;
+          height-mm = <95>;
 
-      width-mm = <63>;
-      height-mm = <95>;
-
-      port {
-        panel_in: endpoint {
-          remote-endpoint = <&mdss_dsi0_out>;
+          port {
+            panel_in: endpoint {
+              remote-endpoint = <&mdss_dsi0_out>;
+            };
+          };
         };
       };
-    };
-...

--- a/Documentation/devicetree/bindings/display/panel/syna,td4310.yaml
+++ b/Documentation/devicetree/bindings/display/panel/syna,td4310.yaml
@@ -26,6 +26,15 @@ properties:
   backlight:
     description: phandle of the backlight device attached to the panel
 
+  vddio-supply:
+    description: power IC supply regulator
+
+  vddpos-supply:
+    description: positive boost supply regulator
+
+  vddneg-supply:
+    description: negative boost supply regulator
+
   port: true
   width-mm: true
   height-mm: true
@@ -34,6 +43,9 @@ required:
   - compatible
   - reg
   - reset-gpios
+  - vddio-supply
+  - vddpos-supply
+  - vddneg-supply
 
 unevaluatedProperties: false
 
@@ -47,6 +59,11 @@ examples:
         compatible = "syna,td4310";
         reg = <0>;
         reset-gpios = <&tlmm 53 GPIO_ACTIVE_LOW>;
+
+        vddio-supply = <&vreg_l11a_1p8>;
+        vddpos-supply = <&lab>;
+        vddneg-supply = <&ibb>;
+
         backlight = <&pm660l_wled>;
         width-mm = <63>;
         height-mm = <95>;

--- a/arch/arm64/boot/dts/qcom/sdm660-bbry-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-bbry-common.dtsi
@@ -12,9 +12,11 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/input/gpio-keys.h>
 
+/delete-node/ &adsp_region;
+/delete-node/ &wlan_msa_mem;
+/delete-node/ &wlan_msa_guard;
 /delete-node/ &qhee_code;
-/delete-node/ &tz_mem;
-/delete-node/ &zap_shader_region;
+/delete-node/ &mpss_region;
 /delete-node/ &rmtfs_mem;
 
 / {
@@ -34,7 +36,7 @@
 
 		framebuffer0: framebuffer@9d400000 {
 			compatible = "simple-framebuffer";
-			reg = <0x0 0x9d400000 0x0 (1080 * 1620 * 4)>;
+			memory-region = <&framebuffer_mem>;
 			status = "okay";
 			width = <1080>;
 			height = <1620>;
@@ -86,12 +88,20 @@
 		};
 	};
 
-	/* Dummy regulator until PM6660 has LCDB VSP/VSN support */
-	lcdb_dummy: regulator-lcdb-dummy {
+	/*
+	 * This is here until we have a driver for QPNP LCDB regulator.
+	 * It can emulate both positive LDO and negative NCP supplies for panel.
+	 */
+	lcdb_fixed: lcdb-regulator {
 		compatible = "regulator-fixed";
-		regulator-name = "lcdb_dummy";
+		regulator-name = "lcdb";
+		/*
+		 * Actual range for LCDB is 4.0 - 6.0V, but
+		 * stock bootloader sets voltage to 5.5 V
+		 */
 		regulator-min-microvolt = <5500000>;
 		regulator-max-microvolt = <5500000>;
+		regulator-boot-on;
 	};
 
 	reserved-memory {
@@ -99,23 +109,15 @@
 		#size-cells = <0x02>;
 		ranges;
 
-		framebuffer_mem: memory@9d400000 {
-			reg = <0x0 0x9d400000 0x0 (1080 * 1620 * 4)>;
+		adsp_region: memory@92a00000 {
+			reg = <0x00 0x92a00000 0x00 0x1e00000>;
 			no-map;
 		};
 
-		zap_shader_region: gpu-zap-mem@fe000000 {
-			compatible = "shared-dma-pool";
-			reg = <0x0 0xfe000000 0x0 0x2000>;
+		reset_log_mem: memory@7e3bc000 {
+			reg = <0x01 0x7e3bc000 0x00 0x4000>;
+			label = "reset_log";
 			no-map;
-		};
-
-		venus_fw_region {
-			compatible = "shared-dma-pool";
-			alloc-ranges = <0x00 0x80000000 0x00 0x20000000>;
-			reusable;
-			alignment = <0x00 0x400000>;
-			size = <0x00 0x800000>;
 		};
 
 		adsp_fw_region {
@@ -126,12 +128,23 @@
 			size = <0x00 0x800000>;
 		};
 
-		qseecom_region {
-			compatible = "shared-dma-pool";
-			alloc-ranges = <0x00 0x00 0x00 0xffffffff>;
+		wlan_msa_mem: memory@85700000 {
+			reg = <0x00 0x85700000 0x00 0x100000>;
+			no-map;
+			qcom,use-guard-pages;
+		};
+
+		qhee_code: memory@85800000 {
+			reg = <0x00 0x85800000 0x00 0x5300000>;
+			no-map;
+		};
+
+		venus_fw_region {
 			reusable;
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0x00 0x80000000 0x00 0x20000000>;
 			alignment = <0x00 0x400000>;
-			size = <0x00 0x1c00000>;
+			size = <0x00 0x800000>;
 		};
 
 		secure_region {
@@ -140,6 +153,18 @@
 			reusable;
 			alignment = <0x00 0x400000>;
 			size = <0x00 0x5c00000>;
+		};
+
+		framebuffer_mem: memory@9d400000 {
+			reg = <0x00 0x9d400000 0x00 0x2300000>;
+			label = "framebuffer";
+			no-map;
+		};
+
+		reset_mem: memory@7e3bb000 {
+			reg = <0x01 0x7e3bb000 0x00 0x1000>;
+			label = "reset";
+			no-map;
 		};
 
 		linux,cma {
@@ -155,9 +180,21 @@
 			compatible = "qcom,rmtfs-mem";
 			reg = <0x0 0xfdc00000 0x0 0x400000>;
 			no-map;
-
 			qcom,client-id = <1>;
 			qcom,vmid = <QCOM_SCM_VMID_MSS_MSA>;
+		};
+
+		mpss_region: memory@8ac00000 {
+			reg = <0x00 0x8ac00000 0x00 0x7e00000>;
+			no-map;
+		};
+
+		qseecom_region {
+			size = <0x00 0x1c00000>;
+			reusable;
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0x00 0x00 0x00 0xffffffff>;
+			alignment = <0x00 0x400000>;
 		};
 	};
 
@@ -317,8 +354,7 @@
 		pinctrl-0 = <&ts_int_active &ts_reset_active>;
 		pinctrl-1 = <&ts_int_sleep &ts_reset_sleep>;
 		pinctrl-names = "default", "sleep";
-		interrupt-parent = <&tlmm>;
-		interrupts = <67 IRQ_TYPE_EDGE_FALLING>;
+		interrupts-extended = <&tlmm 67 IRQ_TYPE_EDGE_FALLING>;
 		vcc-supply = <&vreg_l3b_3p3>;
 		iovcc-supply = <&vreg_l9a_1p8>;
 		reset-gpios = <&tlmm 66 GPIO_ACTIVE_LOW>;
@@ -337,9 +373,12 @@
 		pinctrl-1 = <&ts_int_sleep>;
 		pinctrl-names = "default", "sleep";
 		interrupts-extended = <&tlmm 67 IRQ_TYPE_EDGE_FALLING>;
-		syna,reset-delay-ms = <220>;
-		syna,startup-delay-ms = <600>;
 		vio-supply = <&vreg_l11a_1p8>;
+		vdd-supply = <&lcdb_fixed>;
+		reset-gpios = <&tlmm 53 GPIO_ACTIVE_LOW>;
+		syna,reset-delay-ms = <220>;
+		syna,startup-delay-ms = <2000>;
+
 		status = "disabled";
 
 		rmi4-f01@1 {
@@ -377,6 +416,10 @@
 		pinctrl-names = "default", "sleep";
 		pinctrl-0 = <&mdss_dsi_active &mdss_te_active>;
 		pinctrl-1 = <&mdss_dsi_sleep &mdss_te_sleep>;
+
+		vddio-supply = <&vreg_l11a_1p8>;
+		vddneg-supply = <&lcdb_fixed>;
+		vddpos-supply = <&lcdb_fixed>;
 
 		port {
 			panel_in: endpoint {

--- a/drivers/gpu/drm/panel/panel-boe-bv045fhm-l00.c
+++ b/drivers/gpu/drm/panel/panel-boe-bv045fhm-l00.c
@@ -7,6 +7,7 @@
 #include <linux/gpio/consumer.h>
 #include <linux/mod_devicetable.h>
 #include <linux/module.h>
+#include <linux/regulator/consumer.h>
 
 #include <drm/drm_mipi_dsi.h>
 #include <drm/drm_modes.h>
@@ -17,6 +18,13 @@ struct boe_bv045fhm_l00 {
 	struct drm_panel panel;
 	struct mipi_dsi_device *dsi;
 	struct gpio_desc *reset_gpio;
+	struct regulator_bulk_data* supplies;
+};
+
+static const struct regulator_bulk_data boe_bv045fhm_l00_supplies[] = {
+	{ .supply = "vddio"},
+	{ .supply = "vddneg"},
+	{ .supply = "vddpos"},
 };
 
 static inline struct boe_bv045fhm_l00 *to_boe_bv045fhm_l00(struct drm_panel *panel)
@@ -125,6 +133,10 @@ static int boe_bv045fhm_l00_prepare(struct drm_panel *panel)
 	struct device *dev = &ctx->dsi->dev;
 	int ret;
 
+	ret = regulator_bulk_enable(ARRAY_SIZE(boe_bv045fhm_l00_supplies), ctx->supplies);
+	if (ret < 0)
+		return ret;
+
 	boe_bv045fhm_l00_reset(ctx);
 
 	ret = boe_bv045fhm_l00_on(ctx);
@@ -148,6 +160,8 @@ static int boe_bv045fhm_l00_unprepare(struct drm_panel *panel)
 		dev_err(dev, "Failed to un-initialize panel: %d\n", ret);
 
 	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+
+	regulator_bulk_disable(ARRAY_SIZE(boe_bv045fhm_l00_supplies), ctx->supplies);
 
 	return 0;
 }
@@ -190,6 +204,16 @@ static int boe_bv045fhm_l00_probe(struct mipi_dsi_device *dsi)
 				   DRM_MODE_CONNECTOR_DSI);
 	if (IS_ERR(ctx))
 		return PTR_ERR(ctx);
+
+
+	ret = devm_regulator_bulk_get_const(dev, ARRAY_SIZE(boe_bv045fhm_l00_supplies),
+		boe_bv045fhm_l00_supplies,
+		&ctx->supplies
+	);
+
+	if (ret < 0)
+		return dev_err_probe(dev, ret, "Failed to get regulators\n");
+
 
 	ctx->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_HIGH);
 	if (IS_ERR(ctx->reset_gpio))

--- a/drivers/gpu/drm/panel/panel-synaptics-td4310.c
+++ b/drivers/gpu/drm/panel/panel-synaptics-td4310.c
@@ -7,6 +7,7 @@
 #include <linux/gpio/consumer.h>
 #include <linux/mod_devicetable.h>
 #include <linux/module.h>
+#include <linux/regulator/consumer.h>
 
 #include <drm/drm_mipi_dsi.h>
 #include <drm/drm_modes.h>
@@ -17,6 +18,13 @@ struct synaptics_td4310 {
 	struct drm_panel panel;
 	struct mipi_dsi_device *dsi;
 	struct gpio_desc *reset_gpio;
+	struct regulator_bulk_data* supplies;
+};
+
+static const struct regulator_bulk_data synaptics_td4310_supplies[] = {
+	{ .supply = "vddio"},
+	{ .supply = "vddneg"},
+	{ .supply = "vddpos"},
 };
 
 static inline struct synaptics_td4310 *to_synaptics_td4310(struct drm_panel *panel)
@@ -71,6 +79,13 @@ static int synaptics_td4310_prepare(struct drm_panel *panel)
 	struct device *dev = &ctx->dsi->dev;
 	int ret;
 
+
+	ret = regulator_bulk_enable(ARRAY_SIZE(synaptics_td4310_supplies), ctx->supplies);
+	if (ret < 0)
+		return ret;
+
+	usleep_range(5000, 6000);
+
 	synaptics_td4310_reset(ctx);
 
 	ret = synaptics_td4310_on(ctx);
@@ -94,6 +109,8 @@ static int synaptics_td4310_unprepare(struct drm_panel *panel)
 		dev_err(dev, "Failed to un-initialize panel: %d\n", ret);
 
 	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+
+	regulator_bulk_disable(ARRAY_SIZE(synaptics_td4310_supplies), ctx->supplies);
 
 	return 0;
 }
@@ -136,6 +153,14 @@ static int synaptics_td4310_probe(struct mipi_dsi_device *dsi)
 				   DRM_MODE_CONNECTOR_DSI);
 	if (IS_ERR(ctx))
 		return PTR_ERR(ctx);
+
+	ret = devm_regulator_bulk_get_const(dev, ARRAY_SIZE(synaptics_td4310_supplies),
+		synaptics_td4310_supplies,
+		&ctx->supplies
+	);
+
+	if (ret < 0)
+		return dev_err_probe(dev, ret, "Failed to get regulators\n");
 
 	ctx->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_HIGH);
 	if (IS_ERR(ctx->reset_gpio))


### PR DESCRIPTION
Passes memtest now. Copied from downstream with some tweaks. Tested remoteproc and wifi still work.

Also adding lcd panel regulators to fix syna flakiness and tweaking touchscreen delays.