### PR TITLE
sdm660-bbry: Add audio nodes

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-bbry-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-bbry-common.dtsi
@@ -11,6 +11,8 @@
 #include "pm660l.dtsi"
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/input/gpio-keys.h>
+#include <dt-bindings/sound/qcom,q6afe.h>
+#include <dt-bindings/sound/qcom,q6asm.h>
 
 /delete-node/ &adsp_region;
 /delete-node/ &wlan_msa_mem;
@@ -471,8 +473,41 @@
 	status = "okay";
 };
 
+&lpass_codec {
+	status = "okay";
+};
+
+&pm660l_codec {
+	vdd-cdc-io-supply = <&vreg_s4a_2p04>;
+	vdd-cdc-tx-rx-cx-supply = <&vreg_s4a_2p04>;
+	vdd-micbias-supply = <&vreg_l7b_3p125>;
+	qcom,micbias-lvl = <2600>;
+	qcom,micbias1-ext-cap;
+	status = "okay";
+};
+
 &pon_pwrkey {
 	status = "okay";
+};
+
+&q6afedai {
+	dai@81 { 
+		reg = <LPI_MI2S_RX_0>;
+		qcom,sd-lines = <0 1>;
+	};
+	dai@88 {
+		reg = <LPI_MI2S_TX_3>;
+		qcom,sd-lines = <0 1>; 
+	};
+};
+
+&q6asmdai {
+	dai@0 {
+		reg = <0>;
+	}; 
+	dai@1 {
+		reg = <1>;
+	};
 };
 
 &qusb2phy0 {
@@ -693,6 +728,80 @@
 	};
 };
 
+&lpi_tlmm {
+	/delete-node/ cdc-dmic-default-state;
+};
+
+&sound {
+	compatible = "qcom,sdm660-sndcard";
+	model = "BlackBerry KEY2";
+	pinctrl-0 = <&cdc_pdm_default>, <&headphone_active>, <&speaker_amp_reset_suspend>;
+	pinctrl-names = "default";
+
+	audio-routing = "RX_BIAS", "Digital MCLK",
+					"INT_LDO_H", "Digital MCLK",
+					"Digital RX_I2S_CLK", "Digital MCLK",
+					"Digital TX_I2S_CLK", "Digital MCLK",
+					"Digital ADC1", "ADC1",
+					"Digital ADC2", "ADC2",
+					"Digital ADC3", "ADC3",
+					"PDM_RX1", "Digital PDM_RX1",
+					"PDM_RX2", "Digital PDM_RX2",
+					"PDM_RX3", "Digital PDM_RX3",
+					"Digital LPASS_PDM_TX", "PDM_TX",
+					"AMIC1", "MIC BIAS External1",
+					"AMIC2", "MIC BIAS External2",
+					"AMIC3", "MIC BIAS External1";
+
+	mm1-dai-link {
+		link-name = "MultiMedia1";
+
+		cpu { 
+			sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA1>; 
+		}; 
+	};
+
+	mm2-dai-link {
+		link-name = "MultiMedia2";
+
+		cpu {
+			sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA2>; 
+		};
+	};
+
+	int0-mi2s-dai-link {
+		link-name = "Internal MI2S Playback";
+
+		cpu {
+			sound-dai = <&q6afedai LPI_MI2S_RX_0>; 
+		};
+
+		platform {
+			sound-dai = <&q6routing>; 
+		};
+
+		codec {
+			sound-dai = <&pm660l_codec 0>, <&lpass_codec 0>; 
+		};
+	};
+
+	int3-mi2s-dai-link {
+		link-name = "Internal MI2S Capture";
+
+		cpu {
+			sound-dai = <&q6afedai LPI_MI2S_TX_3>; 
+		};
+
+		platform {
+			sound-dai = <&q6routing>; 
+		};
+
+		codec { 
+			sound-dai = <&pm660l_codec 1>, <&lpass_codec 1>; 
+		};
+	};
+};
+
 &sdhc_1 {
 	bus-width = <8>;
 	non-removable;
@@ -793,6 +902,21 @@
 		drive-strength = <2>;
 		bias-disable;
 		output-low;
+	};
+
+	headphone_active: headphone-active-state {
+		pins = "gpio77";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+		output-high;
+	};
+
+	speaker_amp_reset_suspend: speaker-amp-reset-suspend-state {
+		pins = "gpio48";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-pull-down;
 	};
 };
 


### PR DESCRIPTION
So far earpiece and headphones are tested via proper alsa-ucm-config (https://github.com/sdm660-mainline/alsa-ucm-conf/pull/5)

Speaker works too if you manually set up the amplifier reset pins and send it some i2cset commands.

Microphones remain untested.

AW87319 to be added for speaker amplifier