### PR TITLE
CI: update actions versions

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -13,7 +13,7 @@ jobs:
   build-linux:
     runs-on: [self-hosted, Linux, aarch64]
     steps:
-      - name: Pring debug info and do some pre-run checks
+      - name: Print debug info and do some pre-run checks
         run: |
           echo "GITHUB_WORKSPACE: $GITHUB_WORKSPACE"
           echo "GITHUB_BASE_REF: $GITHUB_BASE_REF"
@@ -28,7 +28,7 @@ jobs:
           doas -n apt update
           doas -n apt -y upgrade
       - name: Checkout linux source from git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           clean: false
       - name: Prepare linux kernel .config using sdm660_defconfig
@@ -68,7 +68,7 @@ jobs:
       - name: Update pmaports
         run: |
           git -C $(pmbootstrap config aports) fetch origin
-          git -C $(pmbootstrap config aports) reset --hard origin/master
+          git -C $(pmbootstrap config aports) reset --hard origin/main
           pmbootstrap status
       - name: Clean pmbootstrap chroots (pmbootstrap zap)
         run: |
@@ -87,7 +87,7 @@ jobs:
       - name: Cleanup pmbootstrap chroots
         run: |
           pmbootstrap shutdown
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: Artifacts
           compression-level: 1

--- a/.github/workflows/check-dtschema.yml
+++ b/.github/workflows/check-dtschema.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 100
       - name: Get changed files


### PR DESCRIPTION
There is a warning printed in GH's actions pages:
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20
and may not work as expected: actions/checkout@v4, actions/upload-artifact@v4.
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
Node.js 20 will be removed from the runner on September 16th, 2026. Please check
if updated versions of these actions are available that support Node.js 24. To opt into
Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment
variable on the runner or in your workflow file. Once Node.js 24 becomes the default,
you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
For more information see:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```
update actions versions to highest to be safe..

Also update pmaports branch name to correct one