### PR TITLE
arm64: dts: qcom: sdm636-xiaomi-tulip: add zap-shader memory region

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -14,6 +14,8 @@
 #include <dt-bindings/sound/qcom,q6afe.h>
 #include <dt-bindings/sound/qcom,q6asm.h>
 
+/delete-node/ &zap_shader_region;
+
 / {
 	model = "Xiaomi Redmi Note 6 Pro";
 	compatible = "xiaomi,tulip", "qcom,sdm636";
@@ -97,6 +99,17 @@
 			reg = <0x0 0x9d400000 0x0 (1080 * 2280 * 4)>;
 			no-map;
 		};
+
+		/*
+		 * From downstream Android dmesg:
+		 * subsys-pil-tz soc:qcom,kgsl-hyp: a512_zap: loading from
+		 *     0x00000000fbc00000 to 0x00000000fbc02000
+		 */
+		zap_shader_region: gpu-zap-mem@fbc00000 {
+			compatible = "shared-dma-pool";
+			reg = <0x0 0xfbc00000 0x0 0x2000>;
+			no-map;
+		};
 	};
 
 	vph_pwr: vph-pwr-regulator {
@@ -133,6 +146,7 @@
 
 &adreno_gpu_zap {
 	firmware-name = "a512_zap.mbn";
+	memory-region = <&zap_shader_region>;
 };
 
 &blsp_i2c1 {


### PR DESCRIPTION
Adreno GPU now properly works.

---

Android dmesg:

```
[    0.434650] subsys-pil-tz cce0000.qcom,venus: invalid resource
[    0.434657] subsys-pil-tz cce0000.qcom,venus: Failed to iomap base register
[    0.435234] subsys-pil-tz cce0000.qcom,venus: for venus segments only will be dumped.
[    0.435658] subsys-pil-tz soc:qcom,kgsl-hyp: invalid resource
[    0.435665] subsys-pil-tz soc:qcom,kgsl-hyp: Failed to iomap base register
[    0.435676] subsys-pil-tz soc:qcom,kgsl-hyp: for a512_zap segments only will be dumped.
[    4.413316] subsys-pil-tz 15700000.qcom,lpass: for adsp segments only will be dumped.
[    7.915177] subsys-pil-tz 15700000.qcom,lpass: adsp: loading from 0x0000000092a00000 to 0x0000000094800000
[    8.259476] subsys-pil-tz 15700000.qcom,lpass: adsp: Brought out of reset
[    8.278932] subsys-pil-tz 15700000.qcom,lpass: Subsystem error monitoring/handling services are up
[    8.279007] subsys-pil-tz 15700000.qcom,lpass: adsp: Power/Clock ready interrupt received
[    8.438999] subsys-pil-tz soc:qcom,kgsl-hyp: a512_zap: loading from 0x00000000fbc00000 to 0x00000000fbc02000
[    8.470088] subsys-pil-tz soc:qcom,kgsl-hyp: a512_zap: Brought out of reset
[   17.908106] subsys-pil-tz cce0000.qcom,venus: venus: loading from 0x000000009cc00000 to 0x000000009d100000
[   17.995432] subsys-pil-tz cce0000.qcom,venus: venus: Brought out of reset
```