### PR TITLE
arm64: dts: qcom: sdm660/636: FAN53526 LPDDR4X VDDQ buck (tulip, jasmine, clover, lavender)

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -168,6 +168,22 @@
 
 &blsp_i2c2 {
 	status = "okay";
+
+	/*
+	 * External FAN53526 buck powering the LPDDR4X VDDQ rail
+	 * (schematic net VREG_LP4X_0P6, nominal 0.6 V). The bootloader
+	 * configures it; keep it always-on and pinned at 0.6 V so the
+	 * regulator core never raises the live DDR rail.
+	 */
+	regulator@60 {
+		compatible = "fcs,fan53526";
+		reg = <0x60>;
+		regulator-min-microvolt = <600000>;
+		regulator-max-microvolt = <600000>;
+		vin-supply = <&vph_pwr>;
+		fcs,suspend-voltage-selector = <1>;
+		regulator-always-on;
+	};
 };
 
 &blsp_i2c6 {

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -185,6 +185,26 @@
 	};
 };
 
+&blsp_i2c2 {
+	status = "okay";
+
+	/*
+	 * External FAN53526 buck powering the LPDDR4X VDDQ rail
+	 * (schematic net VREG_LP4X_0P6, nominal 0.6 V). The bootloader
+	 * configures it; keep it always-on and pinned at 0.6 V so the
+	 * regulator core never raises the live DDR rail.
+	 */
+	regulator@60 {
+		compatible = "fcs,fan53526";
+		reg = <0x60>;
+		regulator-min-microvolt = <600000>;
+		regulator-max-microvolt = <600000>;
+		vin-supply = <&vph_pwr>;
+		fcs,suspend-voltage-selector = <1>;
+		regulator-always-on;
+	};
+};
+
 &mdss {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-jasmine.dts
@@ -163,6 +163,26 @@
 	};
 };
 
+&blsp_i2c2 {
+	status = "okay";
+
+	/*
+	 * External FAN53526 buck powering the LPDDR4X VDDQ rail
+	 * (schematic net VREG_LP4X_0P6, nominal 0.6 V). The bootloader
+	 * configures it; keep it always-on and pinned at 0.6 V so the
+	 * regulator core never raises the live DDR rail.
+	 */
+	regulator@60 {
+		compatible = "fcs,fan53526";
+		reg = <0x60>;
+		regulator-min-microvolt = <600000>;
+		regulator-max-microvolt = <600000>;
+		vin-supply = <&vph_pwr>;
+		fcs,suspend-voltage-selector = <1>;
+		regulator-always-on;
+	};
+};
+
 &mdss {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-lavender-common.dtsi
@@ -160,6 +160,26 @@
 	};
 };
 
+&blsp_i2c2 {
+	status = "okay";
+
+	/*
+	 * External FAN53526 buck powering the LPDDR4X VDDQ rail
+	 * (schematic net VREG_LP4X_0P6, nominal 0.6 V). The bootloader
+	 * configures it; keep it always-on and pinned at 0.6 V so the
+	 * regulator core never raises the live DDR rail.
+	 */
+	regulator@60 {
+		compatible = "fcs,fan53526";
+		reg = <0x60>;
+		regulator-min-microvolt = <600000>;
+		regulator-max-microvolt = <600000>;
+		vin-supply = <&vph_pwr>;
+		fcs,suspend-voltage-selector = <1>;
+		regulator-always-on;
+	};
+};
+
 &mdss {
 	status = "okay";
 };

--- a/drivers/regulator/fan53555.c
+++ b/drivers/regulator/fan53555.c
@@ -76,9 +76,11 @@ enum fan53555_vendor {
 
 enum {
 	FAN53526_CHIP_ID_01 = 1,
+	FAN53526_CHIP_ID_08 = 8,
 };
 
 enum {
+	FAN53526_CHIP_REV_01 = 1,
 	FAN53526_CHIP_REV_08 = 8,
 };
 
@@ -263,6 +265,19 @@ static int fan53526_voltages_setup_fairchild(struct fan53555_device_info *di)
 	case FAN53526_CHIP_ID_01:
 		switch (di->chip_rev) {
 		case FAN53526_CHIP_REV_08:
+			di->vsel_min = 600000;
+			di->vsel_step = 6250;
+			break;
+		default:
+			dev_err(di->dev,
+				"Chip ID %d with rev %d not supported!\n",
+				di->chip_id, di->chip_rev);
+			return -EINVAL;
+		}
+		break;
+	case FAN53526_CHIP_ID_08:
+		switch (di->chip_rev) {
+		case FAN53526_CHIP_REV_01:
 			di->vsel_min = 600000;
 			di->vsel_step = 6250;
 			break;


### PR DESCRIPTION
On all four boards VDDQ for the LPDDR4X is generated by an external FAN53526
at I2C 0x60 on BLSP2 (`&blsp_i2c2`), VIN from VPH_PWR. The schematics name it
directly:

- tulip / jasmine: "Buck for VDRAM", output net `VREG_LP4X_0P6` → R1004 (0R) →
  the DRAM VDDQ pins
- clover: "LPDDR4X external DCDC", FAN53526UC00 marked 0.6 V, output →
  `VSNS_DDR_VDDQ`
- lavender: "Buck for VDRAM" (page 10), FAN53526 U1002, output net
  `VREG_LP4X_0P6` → the DRAM VDDQ pins; board note "INSTALL R535 & DNI R536
  for LP4x" confirms the LPDDR4X population

LPDDR4X VDDQ is 0.6 V (LPDDR4 would be 1.1 V). The bootloader sets this rail up
during DDR init, so the device boots with it already enabled at ~0.6 V:

```
fan53555-regulator 1-0060: FAN53555 Option[8] Rev[1] Detected!
```

## Driver

The chip reports DIE_ID 8 / DIE_REV 1 ("Option[8] Rev[1]"). The driver only knew
chip ID 1 / rev 8, so this part fell through to the `-EINVAL` "Chip ID not
supported" path. Add the ID 8 / rev 1 combination; it uses the same range as the
existing FAN53526 variant (vsel_min 600000 uV, step 6250 uV).

## Device tree

Described at the real 0.6 V operating point and kept on (added under `&blsp_i2c2`
in tulip, jasmine, clover, and lavender):

```
regulator@60 {
	compatible = "fcs,fan53526";
	reg = <0x60>;
	regulator-min-microvolt = <600000>;
	regulator-max-microvolt = <600000>;
	vin-supply = <&vph_pwr>;
	fcs,suspend-voltage-selector = <1>;
	regulator-always-on;
};
```

`min == max == 600000` is intentional. The rail is already up at ~0.6 V from the
bootloader, and this keeps the regulator core from ever raising it. An earlier
attempt used 1.0–1.1 V, which makes the core drive a live VDDQ rail from 0.6 V up
to 1.0 V at registration (`Bringing 618750uV into 1000000-1000000uV`) — well
outside the LPDDR4X VDDQ range. Pinning it at 0.6 V mirrors the existing in-tree
DDR buck node in `msm8994-msft-lumia-octagon.dtsi`.

## Schematics

- clover — "LPDDR4X external DCDC", FAN53526UC00 marked 0.6 V:
<img width="600" alt="clover_fan53526_buck" src="https://github.com/user-attachments/assets/c7e747ed-d562-4aa8-b25d-c77eaede77cf" />

---

- tulip — DRAM VDDQ pins fed by `VREG_LP4X_0P6` (0.6 V):
<img width="600" alt="tulip_ddr_vddq_pins" src="https://github.com/user-attachments/assets/bbdf9a05-a643-42fb-88cb-f6a1c57e7679" />

---

- tulip — FAN53526 "Buck for VDRAM" (0x60, BLSP2, VIN=VPH_PWR):
<img width="600" alt="tulip_fan53526_buck" src="https://github.com/user-attachments/assets/719e0f3f-54cd-427d-8a65-18709cc2eb3b" />

---

- jasmine — DRAM VDDQ pins on VREG_LP4X_0P6 (0.6 V):
<img width="600" alt="jasmine_ddr_vddq_pins" src="https://github.com/user-attachments/assets/b2a6d5b8-95ba-4289-be40-590b63cb8b9d" />

---

- jasmine — FAN53526 "Buck for VDRAM" (page identical to tulip), 0x60 on BLSP2:
<img width="600" alt="jasmine_fan53526_buck" src="https://github.com/user-attachments/assets/b2ecf9b0-c0fe-4b11-a46a-7a434c1848ac" />

---

- lavender — DRAM VDDQ pins on `VREG_LP4X_0P6` (0.6 V); board note "INSTALL R535 & DNI R536 for LP4x" confirms the LPDDR4X population:
<img width="600" alt="lavender_ddr_vddq_pins" src="https://github.com/user-attachments/assets/bb002928-9625-4288-932a-3a06996ab4ea" />

---

- lavender — FAN53526 "Buck for VDRAM" (page 10): 0x60 on BLSP2, VIN=VPH_PWR, output `VREG_LP4X_0P6`:
<img width="600" alt="lavender_fan53526_buck" src="https://github.com/user-attachments/assets/747135ee-a497-4a6c-b2b3-1ba6b3940848" />

## Why the rail already worked without this

The bootloader brings up LPDDR4X and programs this buck to ~0.6 V before Linux starts, and the old DT had no `regulator@60` child, so the driver never bound and the kernel never touched the rail. These commits only describe it and keep it pinned at 0.6 V / always-on — they don't bring it up. (The earlier 1.0–1.1 V version *did* change it, by wrongly raising a live rail.)
