### PR TITLE
Clear some tech debt - revert tulip e7t ts ( #157 )

### DIFF
--- a/Documentation/devicetree/bindings/input/touchscreen/novatek,nvt-ts.yaml
+++ b/Documentation/devicetree/bindings/input/touchscreen/novatek,nvt-ts.yaml
@@ -17,7 +17,6 @@ properties:
     enum:
       - novatek,nt11205-ts
       - novatek,nt36672a-ts
-      - novatek,nt36672a-e7t-ts
 
   reg:
     maxItems: 1

--- a/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
+++ b/arch/arm64/boot/dts/qcom/sdm636-xiaomi-tulip.dts
@@ -160,7 +160,7 @@
 	status = "okay";
 
 	touchscreen@1 {
-		compatible = "novatek,nt36672a-e7t-ts";
+		compatible = "novatek,nt36672a-ts";
 		reg = <0x1>;
 		iovcc-supply = <&vreg_l11a_1p8>;
 		interrupts-extended = <&tlmm 67 IRQ_TYPE_EDGE_RISING>;

--- a/drivers/input/touchscreen/novatek-nvt-ts.c
+++ b/drivers/input/touchscreen/novatek-nvt-ts.c
@@ -405,14 +405,9 @@ static const struct nvt_ts_i2c_chip_data nvt_nt36672a_ts_data = {
 	.chip_id = 0x08,
 };
 
-static const struct nvt_ts_i2c_chip_data nvt_nt36672a_e7t_ts_data = { /* TODO: remove; this is now the same as above and doesn't need extra compatible */
-	.chip_id = 0x08,
-};
-
 static const struct of_device_id nvt_ts_of_match[] = {
 	{ .compatible = "novatek,nt11205-ts", .data = &nvt_nt11205_ts_data },
 	{ .compatible = "novatek,nt36672a-ts", .data = &nvt_nt36672a_ts_data },
-	{ .compatible = "novatek,nt36672a-e7t-ts", .data = &nvt_nt36672a_e7t_ts_data },
 	{ }
 };
 MODULE_DEVICE_TABLE(of, nvt_ts_of_match);
@@ -420,7 +415,6 @@ MODULE_DEVICE_TABLE(of, nvt_ts_of_match);
 static const struct i2c_device_id nvt_ts_i2c_id[] = {
 	{ "nt11205-ts", (unsigned long) &nvt_nt11205_ts_data },
 	{ "nt36672a-ts", (unsigned long) &nvt_nt36672a_ts_data },
-	{ "nt36672a-e7t-ts", (unsigned long) &nvt_nt36672a_e7t_ts_data },
 	{ }
 };
 MODULE_DEVICE_TABLE(i2c, nvt_ts_i2c_id);


### PR DESCRIPTION
Since the commit 7ff574599464bd0e30da88aabc7be9de1021204a (which was sent to mainline by @M0Rf30 ) there is no wake_type check, therefore no need for specific compatible.

This is a "selective" revert of PR #157, "selective" because during initial rebasing our patchset on 7.0.y branch I already had merge conflict, then compilation error accessing non-existing field `.wake_type` so I just removed references to wake_type and left it "as is" to clean later. Which is happening now.