### PR TITLE
Input: novatek-nvt-ts: fix double regulator disable in panel-follower mode

### DIFF
--- a/drivers/input/touchscreen/novatek-nvt-ts.c
+++ b/drivers/input/touchscreen/novatek-nvt-ts.c
@@ -65,6 +65,7 @@ struct nvt_ts_data {
 	 */
 	struct drm_panel_follower panel_follower;
 	bool is_panel_follower;
+	bool running;
 };
 
 static int nvt_ts_read_data(struct i2c_client *client, u8 reg, u8 *data, int count)
@@ -154,6 +155,9 @@ static int nvt_ts_start(struct input_dev *dev)
 	struct nvt_ts_data *data = input_get_drvdata(dev);
 	int error;
 
+	if (data->running)
+		return 0;
+
 	error = regulator_bulk_enable(ARRAY_SIZE(data->regulators), data->regulators);
 	if (error) {
 		dev_err(&data->client->dev, "failed to enable regulators\n");
@@ -164,6 +168,7 @@ static int nvt_ts_start(struct input_dev *dev)
 	gpiod_set_value_cansleep(data->reset_gpio, 0);
 	msleep(100); // TODO: is it really needed? probably
 
+	data->running = true;
 	return 0;
 }
 
@@ -171,9 +176,14 @@ static void nvt_ts_stop(struct input_dev *dev)
 {
 	struct nvt_ts_data *data = input_get_drvdata(dev);
 
+	if (!data->running)
+		return;
+
 	disable_irq(data->client->irq);
 	gpiod_set_value_cansleep(data->reset_gpio, 1);
 	regulator_bulk_disable(ARRAY_SIZE(data->regulators), data->regulators);
+
+	data->running = false;
 }
 
 static int nvt_ts_suspend(struct device *dev)


### PR DESCRIPTION
In panel-follower mode, nvt_ts_stop() can be called twice for a single nvt_ts_start(): first from on_novatek_panel_unpreparing() when the panel powers off, and again from input_close_device() when userspace (e.g. systemd sd-close) closes the evdev file descriptor. This causes an unbalanced regulator disable, triggering a WARNING in the regulator core:

  unbalanced disables for l11
  WARNING: drivers/regulator/core.c:3245 at _regulator_disable+0x7c/0x358

Add a 'running' flag to nvt_ts_data to make nvt_ts_start() and nvt_ts_stop() idempotent. The flag is safe without additional locking as all call paths already hold input->mutex.

Closes: #202 