### PR TITLE
cherry-pick: ASoC: soc-core: use the device tree card name as long_name

### DIFF
--- a/sound/soc/soc-core.c
+++ b/sound/soc/soc-core.c
@@ -3004,6 +3004,14 @@ int snd_soc_of_parse_card_name(struct snd_soc_card *card,
 		return ret;
 	}
 
+	/*
+	 * When setting the OF property in a device tree, the expectation is
+	 * that the UCM config matching the value would be loaded. However if
+	 * a long_name is set, it would be used in the config path instead, and
+	 * snd_soc_set_dmi_name sets long_name to the DMI name if it's unset.
+	 */
+	card->long_name = card->name;
+
 	return 0;
 }
 EXPORT_SYMBOL_GPL(snd_soc_of_parse_card_name);


### PR DESCRIPTION
Cherry-pick patch : https://lore.kernel.org/all/20260506041112.412871-2-val@packett.cool/

Reason: fixes issue when using EFI booting (e.g. with U-Boot) when DMI information is available, if snd-card long name is not set, ALSA composes long card name itself using the form `vendor-product-version` from "BIOS tables". And (short) card name specified in device tree is ignored. ALSA appears to only look at the long name if it is present and does not fall back to the (short) name.

This patch works around this issue on devicetree based systems by setting long name to the same value as short name (from DT), therefore ALSA doesn't try to guess (and be wrong).

See also: https://gitlab.postmarketos.org/postmarketOS/pmaports/-/work_items/4386