### PR TITLE
drm/msm/a5xx: Do not attempt to create debugfs files twice

### DIFF
--- a/drivers/gpu/drm/msm/adreno/a5xx_debugfs.c
+++ b/drivers/gpu/drm/msm/adreno/a5xx_debugfs.c
@@ -164,12 +164,15 @@ void a5xx_debugfs_init(struct msm_gpu *gpu, struct drm_minor *minor)
 
 	dev = minor->dev;
 
-	drm_debugfs_create_files(a5xx_debugfs_list,
-				 ARRAY_SIZE(a5xx_debugfs_list),
-				 minor->debugfs_root, minor);
+	/* Guard against attempts to create duplicates  */
+	if (!debugfs_lookup("reset", minor->debugfs_root)) {
+		drm_debugfs_create_files(a5xx_debugfs_list,
+					 ARRAY_SIZE(a5xx_debugfs_list),
+					 minor->debugfs_root, minor);
 
-	debugfs_create_file_unsafe("reset", S_IWUGO, minor->debugfs_root, dev,
-				&reset_fops);
-	debugfs_create_file_unsafe("speedbin", S_IRUGO, minor->debugfs_root, dev,
-				&speedbin_fops);
+		debugfs_create_file_unsafe("reset", S_IWUGO, minor->debugfs_root, dev,
+					&reset_fops);
+		debugfs_create_file_unsafe("speedbin", S_IRUGO, minor->debugfs_root, dev,
+					&speedbin_fops);
+	}
 }


### PR DESCRIPTION
Sometimes Adreno GPU initialization can happen twice during system bootup: first time in initramfs stage where GPU firmware might be not available, and second time when userspace is almost fully booted in rootfs, when wayland compositor opens drm device for real use.

During the second, "real" GPU initialization happens an attempt to create debugfs files seconds time, causing the following messages in kernel log:

```
 debugfs: 'pfp' already exists in 'c901000.display-controller'
 debugfs: 'me' already exists in 'c901000.display-controller'
 debugfs: 'meq' already exists in 'c901000.display-controller'
 debugfs: 'roq' already exists in 'c901000.display-controller'
 debugfs: 'reset' already exists in 'c901000.display-controller'
```

There is no harm done by that, but 5 extra red lines in dmesg are a bit annoying. But we can avoid that by checking if files already exist in debugfs. We do not have to check every file from the a5xx_debugfs_list, we can only check one of them, and if it doesn't exist, then we can proceed with attempt to create all of them.

Tested on device with a5xx, all the files are still present in debugfs and no more annoying red lines in dmesg.