### PR TITLE
xiaomi-clover tas2557s speakers support

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-xiaomi-clover-common.dtsi
@@ -185,6 +185,29 @@
 	};
 };
 
+&blsp_i2c6 {
+	status = "okay";
+	tas2557_l: codec@4c {         /* left  */
+		compatible = "ti,tas2557";
+		reg = <0x4c>;
+		#sound-dai-cells = <0>;
+		sound-name-prefix = "Left";
+		reset-gpios = <&tlmm 80 GPIO_ACTIVE_LOW>;
+		interrupts-extended = <&tlmm 28 IRQ_TYPE_LEVEL_HIGH>;
+		ti,channel = <0>;      /* DEV_A */
+		firmware-name = "tas2557s_uCDSP.bin";
+      };
+	tas2557_r: codec@4e {         /* right */
+		compatible = "ti,tas2557";
+		reg = <0x4e>;
+		#sound-dai-cells = <0>;
+		sound-name-prefix = "Right";
+		reset-gpios = <&tlmm 48 GPIO_ACTIVE_LOW>;
+		interrupts-extended = <&tlmm 55 IRQ_TYPE_LEVEL_HIGH>;
+		ti,channel = <1>;      /* DEV_B */
+		firmware-name = "tas2557s_uCDSP.bin";
+      };
+};
 &mdss {
 	status = "okay";
 };
@@ -194,6 +217,11 @@
 };
 
 &q6afedai {
+	dai@16 {
+		reg = <PRIMARY_MI2S_RX>;
+		qcom,sd-lines = <0>;
+	};
+
 	dai@81 {
 		reg = <LPI_MI2S_RX_0>;
 		qcom,sd-lines = <0 1>;
@@ -651,7 +679,8 @@
 	compatible = "qcom,sdm660-sndcard";
 	model = "Xiaomi Mi Pad 4";
 	pinctrl-0 = <&cdc_pdm_default>,
-			<&cdc_dmic_default>;
+			<&cdc_dmic_default>,
+			<&pri_mi2s_active>;
 	pinctrl-names = "default";
 	audio-routing = "RX_BIAS", "Digital MCLK",
 			"INT_LDO_H", "Digital MCLK",
@@ -665,7 +694,9 @@
 			"PDM_RX3", "Digital PDM_RX3",
 			"Digital LPASS_PDM_TX", "PDM_TX",
 			"AMIC1", "MIC BIAS External1",
-			"AMIC2", "MIC BIAS External2";
+			"AMIC2", "MIC BIAS External2",
+			"Left ASI2",  "Primary MI2S Playback",
+			"Right ASI2", "Primary MI2S Playback";
 	mm1-dai-link {
 		link-name = "MultiMedia1";
 		cpu {
@@ -678,6 +709,20 @@
 			sound-dai = <&q6asmdai MSM_FRONTEND_DAI_MULTIMEDIA2>;
 		};
 	};
+
+	pri-mi2s-dai-link {
+		link-name = "Primary MI2S Playback";
+		cpu {
+			sound-dai = <&q6afedai PRIMARY_MI2S_RX>;
+		};
+		platform {
+			sound-dai = <&q6routing>;
+		};
+		codec {
+			sound-dai = <&tas2557_l>, <&tas2557_r>;   /* multicodec */
+		};
+	};
+
 	int0-mi2s-dai-link {
 		link-name = "Internal MI2S Playback";
 		cpu {
@@ -729,6 +774,48 @@
 		function = "gpio";
 		drive-strength = <6>;
 		bias-pull-up;
+	};
+
+	pri_mi2s_active: pri-mi2s-active-state {
+		sck-pins  {
+			pins = "gpio12";
+			function = "pri_mi2s";
+			drive-strength = <8>;
+			bias-disable;
+		};
+		ws-pins   {
+			pins = "gpio13";
+			function = "pri_mi2s_ws";
+			drive-strength = <8>;
+			bias-disable;
+		};
+		data-pins {
+			pins = "gpio14", "gpio15";
+			function = "pri_mi2s";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	pri_mi2s_sleep: pri-mi2s-sleep-state {
+		sck-pins  {
+			pins = "gpio12";
+			function = "pri_mi2s";
+			drive-strength = <2>;
+			bias-pull-down;
+		};
+		ws-pins   {
+			pins = "gpio13";
+			function = "pri_mi2s_ws";
+			drive-strength = <2>;
+			bias-pull-down;
+		};
+		data-pins {
+			pins = "gpio14", "gpio15";
+			function = "pri_mi2s";
+			drive-strength = <2>;
+			bias-pull-down;
+		};
 	};
 };
 


### PR DESCRIPTION
This PR adds support for speakers on the xiaomi-clover. Currently only left speaker works.