### PR TITLE
Draft: BlackBerry Navigation Buttons (back/home/task-switch)

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm660-bbry-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm660-bbry-common.dtsi
@@ -271,11 +271,46 @@
 	status = "okay";
 };
 
-
 &blsp_i2c1 {
 	#address-cells = <1>;
 	#size-cells = <0>;
+
 	status = "okay";
+
+	sgm31323: nav-leds@30
+	{
+		compatible = "sgmicro,sgm31323";
+		reg = <0x30>;
+		vdd-supply = <&vreg_bob>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/*
+		 * these two led channels are each half of the nav-btns
+		 * there are 3 buttons so the middle one is chopped in half
+		 * the 3rd channel was unused on my sdm636-bbry-luna-boe
+		 */
+		led@0 {
+			reg = <0>;
+			label = "nav-left";
+			color = <LED_COLOR_ID_WHITE>;
+			led-max-microamp = <5000>;
+			/*
+			 * I wish backlight made it follow the screen but it doesn't seem
+			 * to, so this is the best I can do
+			 */
+			linux,default-trigger = "default-on";
+		};
+
+		led@1 {
+			reg = <1>;
+			label = "nav-right";
+			color = <LED_COLOR_ID_WHITE>;
+			led-max-microamp = <5000>;
+			linux,default-trigger = "default-on";
+		};
+	};
 
 	stmpe1801: port-expander@40
 	{
@@ -360,9 +395,36 @@
 		iovcc-supply = <&vreg_l9a_1p8>;
 		reset-gpios = <&tlmm 66 GPIO_ACTIVE_LOW>;
 		touchscreen-size-x = <1080>;
-		touchscreen-size-y = <1620>;
+		touchscreen-size-y = <1700>;
 		wakeup-source;
 		status = "disabled";
+
+		touch-overlay {
+			segment-1 {
+				x-origin = <150>;
+				y-origin = <1620>;
+				x-size = <100>;
+				y-size = <100>;
+				linux,code = <KEY_BACK>;
+				label = "key-back";
+			};
+			segment-2 {
+				x-origin = <450>;
+				y-origin = <1620>;
+				x-size = <100>;
+				y-size = <100>;
+				linux,code = <KEY_HOMEPAGE>;
+				label = "key-homepage";
+			};
+			segment-3 {
+				x-origin = <750>;
+				y-origin = <1620>;
+				x-size = <100>;
+				y-size = <100>;
+				linux,code = <KEY_APPSELECT>;
+				label = "key-appselect";
+			};
+		};
 	};
 
 	synaptics_touchscreen: touchscreen@70 {
@@ -379,7 +441,6 @@
 		reset-gpios = <&tlmm 53 GPIO_ACTIVE_LOW>;
 		syna,reset-delay-ms = <220>;
 		syna,startup-delay-ms = <2000>;
-
 		status = "disabled";
 
 		rmi4-f01@1 {
@@ -390,6 +451,12 @@
 		rmi4-f11@11 {
 			reg = <0x11>;
 			syna,sensor-type = <1>;
+		};
+
+		 rmi4-f1a@1a {
+			reg = <0x1a>;
+			/* Keys listed from right to left, rightmost key is KEY_APPSELECT */
+			linux,keycodes = <KEY_APPSELECT KEY_HOMEPAGE KEY_BACK>;
 		};
 	};
 };

--- a/drivers/leds/Kconfig
+++ b/drivers/leds/Kconfig
@@ -1028,6 +1028,21 @@ config LEDS_ACER_A500
 	  This option enables support for the Power Button LED of
 	  Acer Iconia Tab A500.
 
+config LEDS_SGM31323
+	tristate "LED Support for SGMicro SGM31323"
+	depends on LEDS_CLASS
+	depends on I2C
+	depends on OF
+	help
+	  This option enables support for the SGMicro general-purpose SGM31323 
+	  3-channel LED driver. It uses an I2C interface.
+	  Found in BlackBerry KEY2, used for Navigation Button LEDs.
+
+	  To compile this driver as a module, choose M here: the module
+	  will be called leds-sgm31323.
+
+
+
 source "drivers/leds/blink/Kconfig"
 
 comment "Flash and Torch LED drivers"

--- a/drivers/leds/Makefile
+++ b/drivers/leds/Makefile
@@ -86,6 +86,7 @@ obj-$(CONFIG_LEDS_PWM)			+= leds-pwm.o
 obj-$(CONFIG_LEDS_QNAP_MCU)		+= leds-qnap-mcu.o
 obj-$(CONFIG_LEDS_REGULATOR)		+= leds-regulator.o
 obj-$(CONFIG_LEDS_SC27XX_BLTC)		+= leds-sc27xx-bltc.o
+obj-$(CONFIG_LEDS_SGM31323)		+= leds-sgm31323.o
 obj-$(CONFIG_LEDS_ST1202)		+= leds-st1202.o
 obj-$(CONFIG_LEDS_SUN50I_A100)		+= leds-sun50i-a100.o
 obj-$(CONFIG_LEDS_SUNFIRE)		+= leds-sunfire.o

--- a/drivers/leds/leds-sgm31323.c
+++ b/drivers/leds/leds-sgm31323.c
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: GPL
+// Driver for SGMicro SGM31323 3-channel LED driver
+
+#include <linux/i2c.h>
+#include <linux/leds.h>
+#include <linux/module.h>
+#include <linux/regulator/consumer.h>
+#include <linux/mutex.h>
+#include <linux/of.h>
+#include <linux/regmap.h>
+
+#define SGM31323_MAX_LEDS 3
+
+#define SGM31323_REG_MAX 0x08
+
+#define SGM31323_REG_ENABLE_RESET		(0)
+#define SGM31323_REG_FLASH_PERIOD		(1)
+#define SGM31323_REG_PWM1_TIMER			(2)
+#define SGM31323_REG_PWM2_TIMER			(3)
+#define SGM31323_REG_CHANNEL_CONTROL		(4)
+#define SGM31323_REG_RAMP_RATE			(5)
+#define SGM31323_REG_ILED(x)			(6+x)
+
+#define SGM31323_REG0_RESET_ALL			(7)
+#define SGM31323_REG0_EN_CTRL_ALWAYS_ON		(3)
+#define SGM31323_REG0_EN_CTRL_SHUTDOWN_MODE	(0)
+#define SGM31323_REG4_EN_TM_ALWAYS_OFF		(0)
+#define SGM31323_REG4_EN_TM_ALWAYS_ON		(1)
+#define SGM31323_REG4_EN_TM_PWM1		(2)
+#define SGM31323_REG4_EN_TM_PWM2		(3)
+#define SGM31323_REG_ILED_STEP			(125) /* microamps */
+#define SGM31323_REG_ILED_MAX			(192) /* 24 milliamps */
+
+#define SGM31323_TIME_STEP			128 /* ms */
+
+enum {
+	SGM31323_REG0_RESET_MODE,
+	SGM31323_REG0_EN_CTRL,
+	SGM31323_REG4_EN_TM_BITMASK_LED0,
+	SGM31323_REG4_EN_TM_BITMASK_LED1,
+	SGM31323_REG4_EN_TM_BITMASK_LED2,
+};
+
+static const struct reg_field sgm31323_fields[] = {
+	[SGM31323_REG0_RESET_MODE] = REG_FIELD(SGM31323_REG_ENABLE_RESET, 0, 2),
+	[SGM31323_REG0_EN_CTRL] = REG_FIELD(SGM31323_REG_ENABLE_RESET, 3, 4),
+	[SGM31323_REG4_EN_TM_BITMASK_LED0] = REG_FIELD(SGM31323_REG_CHANNEL_CONTROL, 0, 1),
+	[SGM31323_REG4_EN_TM_BITMASK_LED1] = REG_FIELD(SGM31323_REG_CHANNEL_CONTROL, 2, 3),
+	[SGM31323_REG4_EN_TM_BITMASK_LED2] = REG_FIELD(SGM31323_REG_CHANNEL_CONTROL, 4, 5),
+};
+
+struct sgm31323;
+
+struct sgm31323_led {
+	struct sgm31323 *chip;
+	struct led_classdev cdev;
+	u32 num;
+	unsigned int imax;
+};
+
+struct sgm31323 {
+	struct mutex mutex; /* held when writing to registers */
+	struct regulator_bulk_data regulators[1]; /* TODO change to non-array calls or add another one for vio */
+	struct i2c_client *client;
+	struct sgm31323_led leds[SGM31323_MAX_LEDS];
+	struct regmap *regmap;
+	struct regmap_field *fields[ARRAY_SIZE(sgm31323_fields)];
+	int num_leds;
+	bool enabled;
+};
+
+static int sgm31323_chip_init(struct sgm31323 *chip)
+{
+	int i, ret;
+
+	ret = regmap_field_write(chip->fields[SGM31323_REG0_EN_CTRL], SGM31323_REG0_EN_CTRL_ALWAYS_ON);
+	if (ret) {
+		dev_err(&chip->client->dev, "Failed to enable the chip: %d\n",
+			ret);
+		return ret;
+	}
+
+	for (i = 0; i < chip->num_leds; i++) {
+		ret = regmap_write(chip->regmap,
+					 SGM31323_REG_ILED(chip->leds[i].num),
+					 chip->leds[i].imax);
+		if (ret) {
+			dev_err(&chip->client->dev,
+				"Failed to set maximum current for led %d: %d\n",
+				chip->leds[i].num, ret);
+			return ret;
+		}
+	}
+
+	return ret;
+}
+
+static void sgm31323_chip_disable(struct sgm31323 *chip)
+{
+	int ret;
+
+	if (!chip->enabled)
+		return;
+
+	ret = regmap_field_write(chip->fields[SGM31323_REG0_EN_CTRL], SGM31323_REG0_EN_CTRL_SHUTDOWN_MODE);
+
+	if (ret) {
+		dev_err(&chip->client->dev, "Failed to disable the chip: %d\n",
+			ret);
+		return;
+	}
+
+	ret = regulator_bulk_disable(ARRAY_SIZE(chip->regulators),
+				     chip->regulators);
+	if (ret) {
+		dev_err(&chip->client->dev,
+			"Failed to disable regulators: %d\n", ret);
+		return;
+	}
+
+	chip->enabled = false;
+}
+
+static int sgm31323_chip_enable(struct sgm31323 *chip)
+{
+	int ret;
+
+	if (chip->enabled)
+		return 0;
+
+	ret = regulator_bulk_enable(ARRAY_SIZE(chip->regulators),
+				    chip->regulators);
+	if (ret) {
+		dev_err(&chip->client->dev,
+			"Failed to enable regulators: %d\n", ret);
+		return ret;
+	}
+	chip->enabled = true;
+
+	ret = sgm31323_chip_init(chip);
+	if (ret)
+		sgm31323_chip_disable(chip);
+
+	return ret;
+}
+
+static bool sgm31323_chip_in_use(struct sgm31323 *chip)
+{
+	int i;
+
+	for (i = 0; i < chip->num_leds; i++)
+		if (chip->leds[i].cdev.brightness)
+			return true;
+
+	return false;
+}
+
+static int sgm31323_brightness_set(struct led_classdev *cdev,
+				   enum led_brightness brightness)
+{
+	struct sgm31323_led *led = container_of(cdev, struct sgm31323_led, cdev);
+	int ret, num;
+
+	mutex_lock(&led->chip->mutex);
+
+	if (sgm31323_chip_in_use(led->chip)) {
+		ret = sgm31323_chip_enable(led->chip);
+		if (ret)
+			goto error;
+	}
+
+	num = led->num;
+
+	if (brightness == LED_ON) {
+		ret = regmap_field_write(led->chip->fields[SGM31323_REG4_EN_TM_BITMASK_LED0+num], SGM31323_REG4_EN_TM_ALWAYS_ON);
+	} else {
+		ret = regmap_field_write(led->chip->fields[SGM31323_REG4_EN_TM_BITMASK_LED0+num], SGM31323_REG4_EN_TM_ALWAYS_OFF);
+	}
+
+	if (ret)
+		goto error;
+
+	if (!sgm31323_chip_in_use(led->chip))
+		sgm31323_chip_disable(led->chip);
+
+error:
+	mutex_unlock(&led->chip->mutex);
+
+	return ret;
+}
+
+/**
+ * SGM31323 doesn't have individual delay_on and delay_off registers.
+ * Instead it has a period and a duty.
+ * Also this doesn't work with different timers on a per-led basis but too bad.
+ */
+static int sgm31323_blink_set(struct led_classdev *cdev,
+			    unsigned long *delay_on, unsigned long *delay_off)
+{
+	struct sgm31323_led *led = container_of(cdev, struct sgm31323_led, cdev);
+	int ret, num = led->num;
+	unsigned long off = 0, on = 0, bigger = 0, total = 0;
+	u32 duty;
+
+	/* If no blink specified, default to 0.9765625Hz. */
+	if (!*delay_off && !*delay_on) {
+		*delay_off = 512;
+		*delay_on = 512;
+	}
+
+	if (!led->cdev.brightness) {
+		led->cdev.brightness = LED_ON;
+		ret = sgm31323_brightness_set(&led->cdev, led->cdev.brightness);
+		if (ret)
+			return ret;
+	}
+
+	/* Never on - just set to off */
+	if (!*delay_on) {
+		led->cdev.brightness = LED_OFF;
+		return sgm31323_brightness_set(&led->cdev, led->cdev.brightness);
+	}
+
+	/* Never off - brightness is already set, disable blinking */
+	if (!*delay_off) {
+		led->cdev.brightness = LED_ON;
+		return sgm31323_brightness_set(&led->cdev, led->cdev.brightness);
+	}
+
+	mutex_lock(&led->chip->mutex);
+
+	/* Convert into values the HW will understand. */
+	off = min(127, DIV_ROUND_CLOSEST(*delay_off, SGM31323_TIME_STEP));
+	on = min(127, DIV_ROUND_CLOSEST(*delay_on, SGM31323_TIME_STEP));
+	bigger = max(off, on);
+	total = on + off;
+
+	if (total == 0) {
+			duty = 0;
+	} else  {
+		/* hacky fixed-point ratio of on/off
+		 * 255 is 99.6% on
+		 * 128 is 50% on
+		 * 0 is always off
+		 */
+		duty = ((on << 8) + (total / 2)) / total;
+		duty = clamp_val(duty, 0, 255);
+		*delay_on = on * SGM31323_TIME_STEP;
+		*delay_off = off * SGM31323_TIME_STEP;
+	}
+
+
+	/* Set timings */
+	ret = regmap_write(led->chip->regmap,
+			   SGM31323_REG_FLASH_PERIOD, total);
+	if (ret)
+		goto out;
+
+	ret = regmap_write(led->chip->regmap,
+			   SGM31323_REG_PWM1_TIMER, duty);
+	if (ret)
+		goto out;
+
+	/* Finally, enable the LED */
+	ret = regmap_field_write(led->chip->fields[SGM31323_REG4_EN_TM_BITMASK_LED0+num], SGM31323_REG4_EN_TM_PWM1);
+out:
+	mutex_unlock(&led->chip->mutex);
+
+	return ret;
+}
+
+static int sgm31323_probe_dt(struct sgm31323 *chip)
+{
+	struct device_node *np = dev_of_node(&chip->client->dev);
+	int count, ret = 0, i = 0;
+	struct sgm31323_led *led;
+
+	count = of_get_available_child_count(np);
+	if (!count || count > SGM31323_MAX_LEDS)
+		return -EINVAL;
+
+	ret = regmap_field_write(chip->fields[SGM31323_REG0_RESET_MODE], SGM31323_REG0_RESET_ALL);
+
+	for_each_available_child_of_node_scoped(np, child) {
+		struct led_init_data init_data = {};
+		u32 source;
+		u32 imax;
+
+		ret = of_property_read_u32(child, "reg", &source);
+		if (ret != 0 || source >= SGM31323_MAX_LEDS) {
+			dev_err(&chip->client->dev,
+				"Couldn't read LED address: %d\n", ret);
+			count--;
+			continue;
+		}
+
+		led = &chip->leds[i];
+		led->num = source;
+		led->chip = chip;
+		init_data.fwnode = of_fwnode_handle(child);
+
+		if (!of_property_read_u32(child, "led-max-microamp", &imax)) {
+			led->imax = min_t(u32, imax / SGM31323_REG_ILED_STEP, SGM31323_REG_ILED_MAX);
+		} else {
+			led->imax = 40; // 5mA
+			dev_info(&chip->client->dev,
+				 "DT property led-max-microamp is missing\n");
+		}
+
+		led->cdev.brightness_set_blocking = sgm31323_brightness_set;
+		led->cdev.blink_set = sgm31323_blink_set;
+		led->cdev.max_brightness = 1;
+
+		ret = devm_led_classdev_register_ext(&chip->client->dev,
+						     &led->cdev, &init_data);
+		if (ret < 0)
+			return ret;
+
+		i++;
+	}
+
+	if (!count)
+		return -EINVAL;
+
+	chip->num_leds = i;
+
+	return 0;
+}
+
+static void sgm31323_chip_disable_action(void *data)
+{
+	sgm31323_chip_disable(data);
+}
+
+static const struct regmap_config sgm31323_regmap_config = {
+	.reg_bits = 8,
+	.val_bits = 8,
+	.max_register = SGM31323_REG_MAX,
+	/* reads return all 0xff, use internal cache for rmw ops */
+	.readable_reg = NULL,
+	.cache_type = REGCACHE_FLAT,
+};
+
+static int sgm31323_probe(struct i2c_client *client)
+{
+	struct sgm31323 *chip;
+	int ret;
+	int i;
+
+	chip = devm_kzalloc(&client->dev, sizeof(*chip), GFP_KERNEL);
+	if (!chip)
+		return -ENOMEM;
+
+	ret = devm_mutex_init(&client->dev, &chip->mutex);
+	if (ret)
+		return ret;
+
+	mutex_lock(&chip->mutex);
+
+	chip->client = client;
+	i2c_set_clientdata(client, chip);
+
+	chip->regmap = devm_regmap_init_i2c(client, &sgm31323_regmap_config);
+	if (IS_ERR(chip->regmap)) {
+		ret = PTR_ERR(chip->regmap);
+		dev_err(&client->dev, "Failed to allocate register map: %d\n",
+			ret);
+		goto error;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(sgm31323_fields); i++) {
+		chip->fields[i] = devm_regmap_field_alloc(&client->dev,
+							  chip->regmap,
+							  sgm31323_fields[i]);
+		if (IS_ERR(chip->fields[i]))
+			return PTR_ERR(chip->fields[i]);
+	}
+
+	chip->regulators[0].supply = "vdd";
+	ret = devm_regulator_bulk_get(&client->dev,
+				      ARRAY_SIZE(chip->regulators),
+				      chip->regulators);
+	if (ret < 0) {
+		if (ret != -EPROBE_DEFER)
+			dev_err(&client->dev,
+				"Failed to request regulators: %d\n", ret);
+		goto error;
+	}
+
+	ret = regulator_bulk_enable(ARRAY_SIZE(chip->regulators),
+				    chip->regulators);
+	if (ret) {
+		dev_err(&client->dev,
+			"Failed to enable regulators: %d\n", ret);
+		goto error;
+	}
+
+	ret = devm_add_action(&client->dev, sgm31323_chip_disable_action, chip);
+	if (ret)
+		goto error_reg;
+
+	ret = sgm31323_probe_dt(chip);
+	if (ret < 0)
+		goto error_reg;
+
+	ret = regulator_bulk_disable(ARRAY_SIZE(chip->regulators),
+				     chip->regulators);
+	if (ret) {
+		dev_err(&client->dev,
+			"Failed to disable regulators: %d\n", ret);
+		goto error;
+	}
+
+	mutex_unlock(&chip->mutex);
+
+	return 0;
+
+error_reg:
+	regulator_bulk_disable(ARRAY_SIZE(chip->regulators),
+			       chip->regulators);
+
+error:
+	mutex_unlock(&chip->mutex);
+	return ret;
+}
+
+static const struct of_device_id sgm31323_match_table[] = {
+	{ .compatible = "sgmicro,sgm31323", },
+	{ /* sentinel */ },
+};
+
+MODULE_DEVICE_TABLE(of, sgm31323_match_table);
+
+static struct i2c_driver sgm31323_driver = {
+	.driver = {
+		.name = "leds-sgm31323",
+		.of_match_table = sgm31323_match_table,
+	},
+	.probe = sgm31323_probe,
+};
+
+module_i2c_driver(sgm31323_driver);
+
+MODULE_AUTHOR("Paul Sajna <sajattack@postmarketos.org>");
+MODULE_DESCRIPTION("SGMicro SGM31323 LED driver");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
For visibilty. Still draft, not passing checkpatch, etc. edt_ft5x06 will need slight modifications to support the touch-overlay property. That will be added later. LED driver for SGM31323 written as a heavily-modified leds-aw2013. leds-aw2013 has some funky outdated idiosyncrasies. Might've wanted to start with something newer. Anyway it mostly works, fully works on synaptics variants if you ask me, (unless you want crazy individual-led blinks) boe variants need the edt_ft5x06 modification mentioned earlier to detect the touch zone of the button.